### PR TITLE
Update AGENTS.md for Next.js 16 guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,15 +1,16 @@
 # personal-site
 
-Next.js 15 (App Router) personal portfolio and blog. React 19, TypeScript, Tailwind CSS, MDX content, Framer Motion animations, Lightning Network payments via Alby SDK (NWC). Deployed on Vercel.
+Next.js 16 (App Router) personal portfolio and blog. React 19, TypeScript 5, Tailwind CSS, MDX content, Framer Motion animations, Lightning Network payments via Alby SDK (NWC). Deployed on Vercel.
 
 ## Setup
 
-- Node 18.18+ (Node 20 LTS recommended)
+- Node 20.9+
 - Enable Corepack: `corepack enable`
 - pnpm is pinned via `packageManager` in package.json
+- Next.js 16 uses Turbopack by default for `next dev` and `next build`; the existing scripts intentionally do not need `--turbopack`
 
 ```sh
-cp .env.example .env.local   # fill at least NEXT_PUBLIC_APP_URL
+cp .env.example .env.local   # fill the vars needed for your workflow
 pnpm install
 pnpm dev                      # http://localhost:3000
 ```
@@ -23,17 +24,34 @@ pnpm dev                      # http://localhost:3000
 - `pnpm test` — Jest + React Testing Library
 - `pnpm test:watch` — watch mode
 
+Note: In Next.js 16, `pnpm build` does not run ESLint automatically. Run `pnpm lint` explicitly.
+
 ## Environment Variables
 
-Required:
-- `NEXT_PUBLIC_APP_URL` — site URL (used for OpenGraph / post metadata)
+Required for core site features:
+- `NOSTR_WALLET_CONNECT_URL` — NWC connection string used by the Lightning invoice and LNURL endpoints
 
-Lightning payments:
-- `NOSTR_WALLET_CONNECT_URL` — NWC connection string for Alby SDK
+Optional site / broadcast config:
+- `NEXT_PUBLIC_APP_URL` — used by `scripts/auto-broadcast.ts` to build absolute URLs for the ConvertKit broadcast workflow. It is not the primary source of site metadata or canonical URLs in the app today; those mostly come from `SITE_URL` in `src/utils/constants.ts` and metadata defined in `src/app/layout.tsx`
 
-Optional LNURL-p config: `LNURL_MIN_SENDABLE`, `LNURL_MAX_SENDABLE`, `LNURL_COMMENT_ALLOWED`, `LNURL_METADATA_TEXT`, `LNURL_METADATA_DESC`
+Optional LNURL-p config:
+- `LNURL_MIN_SENDABLE`
+- `LNURL_MAX_SENDABLE`
+- `LNURL_COMMENT_ALLOWED`
+- `LNURL_METADATA_TEXT`
+- `LNURL_METADATA_DESC`
 
-Optional ConvertKit broadcast (`scripts/auto-broadcast.ts`): `CK_SECRET_KEY`, `CK_PUBLISHER_ID`
+Optional ConvertKit subscribe form:
+- `CONVERTKIT_API_KEY`
+- `CONVERTKIT_FORM_ID`
+
+Optional ConvertKit broadcast script (`scripts/auto-broadcast.ts`):
+- `CK_SECRET_KEY`
+- `CK_PUBLISHER_ID`
+- `NEXT_PUBLIC_APP_URL` is also required when running this script
+
+Present in `.env.example` but currently unused by the codebase:
+- `DEBUG`
 
 ## Project Layout
 
@@ -46,7 +64,7 @@ src/
 │   ├── posts.ts    # getAllPostsMeta(), getPostBySlug(), getPostOgMeta()
 │   ├── security.ts # CSP headers, rate-limit, validators
 │   └── constants.ts# SITE_NAME, SITE_DESCRIPTION, SITE_URL
-├── middleware.ts   # Applies security headers globally
+├── middleware.ts   # Current CSP/security entrypoint; Next.js 16 renames this convention to proxy.ts
 public/             # Static images and icons
 tailwind.config.js  # Custom spacing: section = 3rem
 next.config.js      # Security headers (non-CSP), image domains
@@ -57,11 +75,12 @@ next.config.js      # Security headers (non-CSP), image domains
 - **Routing**: App Router. `src/app/layout.tsx` provides global metadata, theme, fonts, animated background, header/footer. `src/app/page.tsx` composes Profile, SocialBar, and content Sections with LinkCard components.
 - **Content**: MDX posts in `src/posts/*.mdx`. Frontmatter: `title`, `shortTitle` (optional), `date`, `excerpt`, `category`. Parsed by `gray-matter`, rendered via `next-mdx-remote` in RSC.
 - **Styling**: Tailwind-first. Use `space-y-section` for vertical rhythm (3rem). Avoid custom CSS; prefer Tailwind utilities.
+- **Metadata**: Global and page metadata mostly use `SITE_URL` from `src/utils/constants.ts` plus metadata exports in `src/app/**`. Post OG metadata is generated in `src/utils/posts.ts`. `NEXT_PUBLIC_APP_URL` is currently for the broadcast script, not the main metadata source of truth.
 - **Background**: `ClientGalaxyBackground` renders an animated canvas. CSP must allow `data:`, `blob:`, and worker sources for it to function.
 
 ## Security
 
-CSP is managed exclusively through middleware (`src/middleware.ts` → `src/utils/security.ts`). **Do not** add CSP via `next.config.js` or `<meta>` tags.
+Security headers are currently applied via `src/middleware.ts` -> `src/utils/security.ts`. In Next.js 16, the `middleware.ts` file convention is deprecated in favor of `proxy.ts`, so treat this as the repo's current implementation detail rather than new framework guidance. CSP is still managed exclusively from this path. **Do not** add CSP via `next.config.js` or `<meta>` tags.
 
 When adding external services:
 - Update `connect-src`, `img-src`, `font-src`, etc. in `src/utils/security.ts`
@@ -90,13 +109,13 @@ Helpers in `src/utils/security.ts`: `getClientIP()`, `rateLimit()`, validators (
    category: "Daily Word"
    ```
 3. The homepage displays the latest post via `getAllPostsMeta()[0]`
-4. OG/Twitter metadata requires `NEXT_PUBLIC_APP_URL` to be set
+4. OG/Twitter metadata for the site and posts currently derives from `SITE_URL` in `src/utils/constants.ts` and metadata exports in `src/app/**`; `NEXT_PUBLIC_APP_URL` is only required for `scripts/auto-broadcast.ts`
 
 ## Deployment
 
 - Platform: Vercel
-- Set env vars in Vercel dashboard (`NEXT_PUBLIC_APP_URL`, `NOSTR_WALLET_CONNECT_URL`, etc.)
-- CSP comes only from middleware — do not duplicate
+- Set the env vars needed by the features you are deploying: `NOSTR_WALLET_CONNECT_URL` for Lightning flows, `CONVERTKIT_API_KEY` / `CONVERTKIT_FORM_ID` for `/api/subscribe`, and `CK_SECRET_KEY` / `CK_PUBLISHER_ID` plus `NEXT_PUBLIC_APP_URL` for `scripts/auto-broadcast.ts`
+- CSP comes only from `src/middleware.ts` -> `src/utils/security.ts` in the current repo; do not duplicate it in `next.config.js` or `<meta>` tags
 - Verify in preview/prod: check Network tab for a single CSP header with expected directives
 
 ## Troubleshooting


### PR DESCRIPTION
## Summary
- Refreshes the repo guidance for Next.js 16, including the Node 20.9+ requirement and Turbopack defaults.
- Clarifies environment variable usage, separating core site, LNURL, ConvertKit subscribe, and broadcast script settings.
- Updates architecture, security, deployment, and post-publishing notes to reflect current metadata and CSP sources.

## Testing
- Not run (documentation-only change)
- Reviewed the updated `AGENTS.md` content for consistency with the repo's current Next.js 16 setup and env var usage