### PR TITLE
Add reduced-motion support for animated background effects

### DIFF
--- a/src/components/ClientSnowflakes.test.tsx
+++ b/src/components/ClientSnowflakes.test.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { act, render, screen } from '@testing-library/react';
+
+import ClientSnowflakes from '@/components/ClientSnowflakes';
+import { installMatchMediaMock } from '@/test-utils/mockMatchMedia';
+
+jest.mock('@/components/Snowflakes', () => ({
+  __esModule: true,
+  default: () => <div data-testid="snowflakes-layer" />,
+}));
+
+describe('ClientSnowflakes', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('suppresses snowflakes when reduced motion is enabled', () => {
+    installMatchMediaMock(true);
+    window.localStorage.setItem('showSnowflakes', 'true');
+
+    render(<ClientSnowflakes />);
+
+    expect(screen.queryByTestId('snowflakes-layer')).not.toBeInTheDocument();
+    expect(
+      screen.getByRole('button', {
+        name: 'Snowflakes are hidden while Reduce Motion is enabled',
+      })
+    ).toBeInTheDocument();
+  });
+
+  it('restores snowflakes when reduced motion is turned off', () => {
+    const matchMediaController = installMatchMediaMock(true);
+    window.localStorage.setItem('showSnowflakes', 'true');
+
+    render(<ClientSnowflakes />);
+
+    expect(screen.queryByTestId('snowflakes-layer')).not.toBeInTheDocument();
+
+    act(() => {
+      matchMediaController.setMatches(false);
+    });
+
+    expect(screen.getByTestId('snowflakes-layer')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Hide snowflakes' })).toBeInTheDocument();
+  });
+});

--- a/src/components/ClientSnowflakes.tsx
+++ b/src/components/ClientSnowflakes.tsx
@@ -1,7 +1,9 @@
 'use client';
 
-import React, { useState, useSyncExternalStore } from 'react';
+import React, { useEffect, useState, useSyncExternalStore } from 'react';
 import Snowflakes from './Snowflakes';
+
+const REDUCED_MOTION_QUERY = '(prefers-reduced-motion: reduce)';
 
 function subscribe() {
   return () => {};
@@ -13,6 +15,13 @@ const ClientSnowflakes: React.FC = () => {
     () => true,
     () => false
   );
+  const [reducedMotion, setReducedMotion] = useState(() => {
+    if (typeof window === 'undefined') {
+      return false;
+    }
+
+    return window.matchMedia(REDUCED_MOTION_QUERY).matches;
+  });
   const [showSnowflakes, setShowSnowflakes] = useState(() => {
     if (typeof window === 'undefined') {
       return false;
@@ -30,7 +39,30 @@ const ClientSnowflakes: React.FC = () => {
       return false;
     }
   });
-  const snowflakesVisible = hydrated && showSnowflakes;
+
+  useEffect(() => {
+    const mq = window.matchMedia(REDUCED_MOTION_QUERY);
+
+    const handleMotionPreferenceChange = (event: MediaQueryListEvent) => {
+      setReducedMotion(event.matches);
+    };
+
+    mq.addEventListener('change', handleMotionPreferenceChange);
+
+    return () => {
+      mq.removeEventListener('change', handleMotionPreferenceChange);
+    };
+  }, []);
+
+  const snowflakesVisible = hydrated && showSnowflakes && !reducedMotion;
+  const toggleLabel = reducedMotion
+    ? showSnowflakes
+      ? 'Snowflakes are hidden while Reduce Motion is enabled'
+      : 'Snowflakes are off and will stay hidden while Reduce Motion is enabled'
+    : snowflakesVisible
+      ? 'Hide snowflakes'
+      : 'Show snowflakes';
+  const toggleIcon = showSnowflakes ? '❄️' : '☃️';
 
   // Save preference to localStorage when it changes
   const toggleSnowflakes = () => {
@@ -45,10 +77,10 @@ const ClientSnowflakes: React.FC = () => {
       <button
         onClick={toggleSnowflakes}
         className="fixed bottom-6 right-6 z-50 p-3 rounded-full bg-white/10 backdrop-blur-sm hover:bg-white/20 transition-all shadow-lg"
-        aria-label={snowflakesVisible ? 'Hide snowflakes' : 'Show snowflakes'}
-        title={snowflakesVisible ? 'Hide snowflakes' : 'Show snowflakes'}
+        aria-label={toggleLabel}
+        title={toggleLabel}
       >
-        <span className="text-2xl">{snowflakesVisible ? '❄️' : '☃️'}</span>
+        <span className="text-2xl">{toggleIcon}</span>
       </button>
     </>
   );

--- a/src/components/GalaxyBackground.test.tsx
+++ b/src/components/GalaxyBackground.test.tsx
@@ -1,0 +1,83 @@
+import React from 'react';
+import { act, render } from '@testing-library/react';
+
+import GalaxyBackground from '@/components/GalaxyBackground';
+import { installMatchMediaMock } from '@/test-utils/mockMatchMedia';
+
+describe('GalaxyBackground', () => {
+  const mockGradient = {
+    addColorStop: jest.fn(),
+  };
+  const mockContext = {
+    fillStyle: '',
+    fillRect: jest.fn(),
+    beginPath: jest.fn(),
+    arc: jest.fn(),
+    fill: jest.fn(),
+    createRadialGradient: jest.fn(() => mockGradient),
+  };
+
+  beforeEach(() => {
+    let nextFrameId = 1;
+
+    Object.defineProperty(window, 'requestAnimationFrame', {
+      configurable: true,
+      writable: true,
+      value: jest.fn(() => nextFrameId++),
+    });
+
+    Object.defineProperty(window, 'cancelAnimationFrame', {
+      configurable: true,
+      writable: true,
+      value: jest.fn(),
+    });
+
+    Object.defineProperty(HTMLCanvasElement.prototype, 'getContext', {
+      configurable: true,
+      value: jest.fn(() => mockContext),
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('starts animating when reduced motion is off', () => {
+    installMatchMediaMock(false);
+
+    const { container } = render(<GalaxyBackground />);
+
+    expect(container.querySelector('canvas')).toBeInTheDocument();
+    expect(window.requestAnimationFrame).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders a static frame when reduced motion is on', () => {
+    installMatchMediaMock(true);
+
+    render(<GalaxyBackground />);
+
+    expect(window.requestAnimationFrame).not.toHaveBeenCalled();
+    expect(mockContext.fillRect).toHaveBeenCalled();
+  });
+
+  it('responds to live reduced-motion changes without remounting', () => {
+    const matchMediaController = installMatchMediaMock(false);
+
+    render(<GalaxyBackground />);
+
+    expect(window.requestAnimationFrame).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      matchMediaController.setMatches(true);
+    });
+
+    expect(window.cancelAnimationFrame).toHaveBeenCalledWith(1);
+    expect(window.requestAnimationFrame).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      matchMediaController.setMatches(false);
+    });
+
+    expect(window.requestAnimationFrame).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/components/GalaxyBackground.tsx
+++ b/src/components/GalaxyBackground.tsx
@@ -1,14 +1,37 @@
 'use client';
 
-import React, { useEffect, useRef, ReactNode } from 'react';
+import React, { useEffect, useRef, useState, ReactNode } from 'react';
 
 // Props for GalaxyBackground, allowing optional children to render on top of the canvas
 interface GalaxyBackgroundProps {
   children?: ReactNode;
 }
 
+const REDUCED_MOTION_QUERY = '(prefers-reduced-motion: reduce)';
+
 const GalaxyBackground: React.FC<GalaxyBackgroundProps> = ({ children }) => {
   const canvasRef = useRef<HTMLCanvasElement>(null);
+  const [reducedMotion, setReducedMotion] = useState(() => {
+    if (typeof window === 'undefined') {
+      return false;
+    }
+
+    return window.matchMedia(REDUCED_MOTION_QUERY).matches;
+  });
+
+  useEffect(() => {
+    const mq = window.matchMedia(REDUCED_MOTION_QUERY);
+
+    const handleMotionPreferenceChange = (event: MediaQueryListEvent) => {
+      setReducedMotion(event.matches);
+    };
+
+    mq.addEventListener('change', handleMotionPreferenceChange);
+
+    return () => {
+      mq.removeEventListener('change', handleMotionPreferenceChange);
+    };
+  }, []);
 
   useEffect(() => {
     // Retrieve CSS variables or fallback to defaults
@@ -43,14 +66,6 @@ const GalaxyBackground: React.FC<GalaxyBackgroundProps> = ({ children }) => {
     const ctx = canvas.getContext('2d', { alpha: true });
     if (!ctx) return;
 
-    // Set canvas size
-    const setCanvasSize = () => {
-      canvas.width = window.innerWidth;
-      canvas.height = window.innerHeight;
-    };
-    setCanvasSize();
-    window.addEventListener('resize', setCanvasSize);
-
     // Star properties
     const stars: {
       x: number;
@@ -62,44 +77,43 @@ const GalaxyBackground: React.FC<GalaxyBackgroundProps> = ({ children }) => {
     }[] = [];
     const numStars = 150; // Reduced star count for better performance
 
-    // Initialize stars
-    for (let i = 0; i < numStars; i++) {
-      stars.push({
-        x: Math.random() * canvas.width,
-        y: Math.random() * canvas.height,
-        size: Math.random() * 2,
-        brightness: Math.random(),
-        speed: 0.005 + Math.random() * 0.02,
-        color: Math.random(),
-      });
-    }
+    const populateStars = () => {
+      stars.length = 0;
 
-    // Draw first solid background frame
-    ctx.fillStyle = `rgb(${bgRgb.r}, ${bgRgb.g}, ${bgRgb.b})`;
-    ctx.fillRect(0, 0, canvas.width, canvas.height);
+      for (let i = 0; i < numStars; i++) {
+        stars.push({
+          x: Math.random() * canvas.width,
+          y: Math.random() * canvas.height,
+          size: Math.random() * 2,
+          brightness: Math.random(),
+          speed: 0.005 + Math.random() * 0.02,
+          color: Math.random(),
+        });
+      }
+    };
 
-    // Animation loop
-    let animationFrameId: number;
-    let time = 0;
-    const animate = () => {
-      time += 0.002; // Slower time increment for smoother animation
+    const setCanvasSize = () => {
+      canvas.width = window.innerWidth;
+      canvas.height = window.innerHeight;
+    };
 
-      // Apply a semi-transparent layer to create trails
-      ctx.fillStyle = `rgba(${bgRgb.r}, ${bgRgb.g}, ${bgRgb.b}, 0.5)`; // 50% opacity
+    const drawBackground = (opacity = 1) => {
+      ctx.fillStyle =
+        opacity === 1
+          ? `rgb(${bgRgb.r}, ${bgRgb.g}, ${bgRgb.b})`
+          : `rgba(${bgRgb.r}, ${bgRgb.g}, ${bgRgb.b}, ${opacity})`;
       ctx.fillRect(0, 0, canvas.width, canvas.height);
+    };
 
-      // Draw and update stars
+    const drawStars = () => {
       stars.forEach((star) => {
-        // More subtle pulsating effect
         const opacity = 0.2 + Math.sin(time * 2 + star.brightness * 10) * 0.2;
 
-        // Subtle color variation around the accent color
         ctx.fillStyle = `rgba(${accentRgb.r}, ${accentRgb.g}, ${accentRgb.b}, ${opacity})`;
         ctx.beginPath();
         ctx.arc(star.x, star.y, star.size, 0, Math.PI * 2);
         ctx.fill();
 
-        // Optional subtle glow effect for larger stars
         if (star.size > 1.5) {
           ctx.beginPath();
           ctx.arc(star.x, star.y, star.size * 2, 0, Math.PI * 2);
@@ -111,28 +125,72 @@ const GalaxyBackground: React.FC<GalaxyBackgroundProps> = ({ children }) => {
             star.y,
             star.size * 3
           );
-          gradient.addColorStop(0, `rgba(${accentRgb.r}, ${accentRgb.g}, ${accentRgb.b}, 0.125)`); // 12.5% opacity
-          gradient.addColorStop(1, `rgba(${accentRgb.r}, ${accentRgb.g}, ${accentRgb.b}, 0)`); // 0% opacity
+          gradient.addColorStop(0, `rgba(${accentRgb.r}, ${accentRgb.g}, ${accentRgb.b}, 0.125)`);
+          gradient.addColorStop(1, `rgba(${accentRgb.r}, ${accentRgb.g}, ${accentRgb.b}, 0)`);
           ctx.fillStyle = gradient;
           ctx.fill();
         }
+      });
+    };
 
-        // Update star position with parallax effect (more subtle)
+    const updateStars = () => {
+      stars.forEach((star) => {
         star.y = (star.y + star.speed) % canvas.height;
         star.x += Math.sin(time + star.brightness) * 0.1;
         star.x = (star.x + canvas.width) % canvas.width;
       });
-
-      animationFrameId = requestAnimationFrame(animate);
     };
 
-    animate();
+    const drawStaticFrame = () => {
+      drawBackground();
+      drawStars();
+    };
+
+    const handleResize = () => {
+      setCanvasSize();
+      populateStars();
+
+      if (reducedMotion) {
+        drawStaticFrame();
+        return;
+      }
+
+      drawBackground();
+      drawStars();
+    };
+
+    setCanvasSize();
+    populateStars();
+    window.addEventListener('resize', handleResize);
+
+    let animationFrameId: number | null = null;
+    let time = 0;
+
+    const animate = () => {
+      time += 0.002; // Slower time increment for smoother animation
+
+      drawBackground(0.5);
+      drawStars();
+      updateStars();
+
+      animationFrameId = window.requestAnimationFrame(animate);
+    };
+
+    drawBackground();
+    drawStars();
+
+    if (!reducedMotion) {
+      animationFrameId = window.requestAnimationFrame(animate);
+    }
 
     return () => {
-      window.removeEventListener('resize', setCanvasSize);
-      cancelAnimationFrame(animationFrameId);
+      window.removeEventListener('resize', handleResize);
+
+      if (animationFrameId !== null) {
+        window.cancelAnimationFrame(animationFrameId);
+      }
     };
-  }, []);
+  }, [reducedMotion]);
 
   return (
     <>

--- a/src/test-utils/mockMatchMedia.ts
+++ b/src/test-utils/mockMatchMedia.ts
@@ -1,0 +1,61 @@
+type MediaQueryChangeListener = (event: MediaQueryListEvent) => void;
+
+export function installMatchMediaMock(initialMatches = false) {
+  let matches = initialMatches;
+  const listeners = new Set<MediaQueryChangeListener>();
+
+  const mediaQueryList = {
+    media: '(prefers-reduced-motion: reduce)',
+    onchange: null as ((this: MediaQueryList, event: MediaQueryListEvent) => void) | null,
+    get matches() {
+      return matches;
+    },
+    addEventListener: jest.fn(
+      (type: string, listener: EventListenerOrEventListenerObject) => {
+        if (type === 'change' && typeof listener === 'function') {
+          listeners.add(listener as MediaQueryChangeListener);
+        }
+      }
+    ),
+    removeEventListener: jest.fn(
+      (type: string, listener: EventListenerOrEventListenerObject) => {
+        if (type === 'change' && typeof listener === 'function') {
+          listeners.delete(listener as MediaQueryChangeListener);
+        }
+      }
+    ),
+    addListener: jest.fn((listener: MediaQueryChangeListener) => {
+      listeners.add(listener);
+    }),
+    removeListener: jest.fn((listener: MediaQueryChangeListener) => {
+      listeners.delete(listener);
+    }),
+    dispatchEvent: jest.fn((event: Event) => {
+      listeners.forEach((listener) => listener(event as MediaQueryListEvent));
+      mediaQueryList.onchange?.call(mediaQueryList as MediaQueryList, event as MediaQueryListEvent);
+      return true;
+    }),
+  };
+
+  const matchMedia = jest.fn().mockImplementation(() => mediaQueryList);
+
+  Object.defineProperty(window, 'matchMedia', {
+    configurable: true,
+    writable: true,
+    value: matchMedia,
+  });
+
+  return {
+    matchMedia,
+    mediaQueryList: mediaQueryList as MediaQueryList,
+    setMatches(nextMatches: boolean) {
+      matches = nextMatches;
+      const event = {
+        matches: nextMatches,
+        media: mediaQueryList.media,
+      } as MediaQueryListEvent;
+
+      mediaQueryList.dispatchEvent(event as unknown as Event);
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- detect `prefers-reduced-motion` in `GalaxyBackground` and switch the canvas to a single static star-field frame
- stop rendering animated snowflakes while reduced motion is enabled without clearing the saved user toggle
- update snowflake button labels to reflect when motion is suppressed by the system setting
- add focused Jest coverage for media-query changes and reduced-motion behavior

## Testing
- `pnpm test -- --runInBand src/components/GalaxyBackground.test.tsx src/components/ClientSnowflakes.test.tsx`
- `pnpm exec eslint src/components/GalaxyBackground.tsx src/components/ClientSnowflakes.tsx src/components/GalaxyBackground.test.tsx src/components/ClientSnowflakes.test.tsx src/test-utils/mockMatchMedia.ts`