### PR TITLE
Devotion: The Man the Rooster-Crow Peter Became

### DIFF
--- a/src/posts/2026-04-09-the-rooster-crow-peter-became.mdx
+++ b/src/posts/2026-04-09-the-rooster-crow-peter-became.mdx
@@ -1,0 +1,34 @@
+---
+title: 'The Man the Rooster-Crow Peter Became'
+date: '2026-04-09'
+excerpt: 'The same man who couldn''t admit knowing Jesus in a courtyard stood before thousands at Pentecost and preached Him without flinching. Same Peter. Completely different source of power.'
+category: 'Daily Word'
+series: 'The God Who Restores What You Break'
+tags:
+  - 'Acts 2'
+  - 'Holy Spirit'
+  - 'Transformation'
+  - 'Courage'
+---
+
+> But Peter, standing up with the eleven, lifted up his voice, and said unto them, Ye men of Judaea, and all ye that dwell at Jerusalem, be this known unto you, and hearken to my words. — Acts 2:14 (KJV)
+
+A few weeks earlier, Peter couldn't tell a servant girl that he knew Jesus. In a courtyard, with no official threat, no sword at his throat, just a girl asking a simple question — he folded three times. The same voice that said *"I will lay down my life for Thy sake"* said *"I know not the man."*
+
+Now here he is at Pentecost, standing in front of thousands in the city where Jesus was just crucified, lifting his voice to preach the name he denied. Three thousand people are baptized by the end of the day.
+
+Same Peter. The transformation is total.
+
+## Where the Courage Came From
+
+The difference isn't willpower. Peter didn't read a book on boldness or decide to try harder this time. Jesus had told him explicitly: *you will receive power when the Holy Ghost comes upon you.* That's not metaphor. That's a description of what happened to Peter in that upper room. The courage he showed at Pentecost wasn't courage he drummed up — it came down.
+
+But there's something worth noticing: Peter had to fail first. He had to discover the limits of his own strength. If Peter had somehow managed to stay faithful in that courtyard, he might have carried that into the rest of his ministry. "I can do this. I've got what it takes." Instead, he knew. He had tasted his own cowardice and wept over it. When the Spirit came and filled him with power, he had no illusions about where it was coming from.
+
+## The Failure That Made the Message
+
+The most powerful preachers aren't the ones who've never stumbled. They're the ones who stumbled, were restored, and are honest about both. Peter's sermon at Pentecost doesn't lean on his own credibility — it leans on the resurrection. He knows something about failure and comeback from personal experience, and that personal experience gives his words weight.
+
+Where has your own failure become the foundation for something you can offer others? Not a reason to stay silent — a reason to speak. The people sitting across from you who feel like their worst moment disqualifies them need to hear from someone who knows what it's like to be disqualified and restored.
+
+Your stumble isn't the end of your story. For Peter, it was the beginning of the part God had always planned.


### PR DESCRIPTION
## Daily Devotion — 2026-04-09

**Source:** Lesson 06 — The God Who Restores What You Break (Thursday entry)

> The same man who couldn't admit knowing Jesus in a courtyard stood before thousands at Pentecost and preached Him without flinching. Same Peter. Completely different source of power.

---
Once merged, the devotion-broadcast workflow will automatically send this to The Daily Word subscribers via ConvertKit.
