### PR TITLE
Devotion: Stop Saving Your Life

### DIFF
--- a/src/posts/2026-04-10-stop-saving-your-life.mdx
+++ b/src/posts/2026-04-10-stop-saving-your-life.mdx
@@ -1,0 +1,40 @@
+---
+title: 'Stop Saving Your Life'
+date: '2026-04-10'
+excerpt: 'Peter tried to save his life in the courtyard and lost everything. When he finally stopped hiding, God gave him a life bigger than anything he could have protected.'
+category: 'Daily Word'
+series: 'The God Who Restores What You Break'
+tags:
+  - 'Matthew 16'
+  - 'Surrender'
+  - 'Vulnerability'
+  - 'Faith'
+---
+
+> For whosoever will save his life shall lose it: and whosoever will lose his life for my sake shall find it. — Matthew 16:25 (KJV)
+
+Peter tried to save his life in that courtyard. He covered himself. He protected his reputation. He chose safety over truth three times in a row. And in doing so, he lost the very thing he was trying to hold onto — his identity as a follower of Jesus, his sense of himself as a man of courage, his place in the story he'd given three years to.
+
+That's the paradox. The tighter you hold on, the more you lose.
+
+## What "Saving Your Life" Actually Looks Like
+
+For most of us, saving our life doesn't look like denying Jesus in a courtyard. It looks quieter than that. It looks like keeping our failures private so no one knows we struggled. It looks like curating what we share so we always appear to have it together. It looks like staying silent when our honest story might actually help someone, because we'd rather be seen as having the answers than as someone who needed God's rescue.
+
+We save our image. We save our reputation. We save the version of ourselves that feels acceptable. And we lose the freedom that comes from being known and still loved.
+
+## When Peter Finally Stopped
+
+At Pentecost, Peter stopped saving himself. He stood up and preached the resurrection of a man he had publicly denied. He became known as the coward turned apostle. He let his worst moment be part of the record.
+
+And that's when the life he'd been trying to protect finally arrived. Three thousand conversions. The church planted. Decades of ministry. His stumble became his sermon, his failure became his foundation, and his restoration became the message that changed the world.
+
+You can't manufacture that kind of impact. You can only receive it — but only after you stop trying to control the story.
+
+## The Question Worth Carrying
+
+Are you living this truth or just knowing it? There's a version of faith where we affirm the paradox of losing to find without ever practicing it. We nod at the sermon and then go back to carefully managing how we're perceived.
+
+The invitation today is simpler and harder than it sounds: let one thing be honest that you've been keeping polished. Not to perform vulnerability, but to practice actually losing your life for Jesus. Put something real on the table and see what God does with it.
+
+Peter's story isn't about his failure. It's about what a God who restores broken people can do when you finally stop trying to save yourself.


### PR DESCRIPTION
## Daily Devotion — 2026-04-10

**Source:** Lesson 06 — The God Who Restores What You Break (Friday entry)

> Peter tried to save his life in the courtyard and lost everything. When he finally stopped hiding, God gave him a life bigger than anything he could have protected.

---
Once merged, the devotion-broadcast workflow will automatically send this to The Daily Word subscribers via ConvertKit.
