### PR TITLE
Remove snowflake animation for off-season

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,24 @@ The app uses a consistent vertical spacing system:
 - The profile section sits at the top with proper spacing to content below
 - Social bar and sections maintain visual hierarchy through spacing
 
+### Seasonal Features
+
+The snowflake animation (falling snow with a toggle button) is a **winter-only** feature. It was removed from the active layout because it is distracting outside of winter, especially on mobile.
+
+To re-enable it for the winter season:
+
+1. Open `src/app/layout.tsx`
+2. Add the import: `import ClientSnowflakes from '@/components/ClientSnowflakes';`
+3. Add the component inside the background `<div>`, after `<ClientGalaxyBackground />`:
+   ```tsx
+   {/* Winter snowflakes with toggle */}
+   <ClientSnowflakes />
+   ```
+
+The component files are preserved at:
+- `src/components/Snowflakes.tsx` — canvas-based snowflake animation
+- `src/components/ClientSnowflakes.tsx` — client-side toggle with reduced-motion support
+
 ### Development Tips
 
 1. **Content Updates**: Most content is defined in `src/app/page.tsx` as JavaScript objects

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,7 +5,6 @@ import Header from '@/components/layout/Header';
 import Footer from '@/components/layout/Footer';
 import { SITE_NAME, SITE_DESCRIPTION, SITE_URL } from '@/utils/constants';
 import ClientGalaxyBackground from '@/components/ClientGalaxyBackground';
-import ClientSnowflakes from '@/components/ClientSnowflakes';
 import { Analytics } from '@vercel/analytics/react';
 import { SpeedInsights } from '@vercel/speed-insights/next';
 
@@ -90,8 +89,6 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         >
           {/* Client-only animated background */}
           <ClientGalaxyBackground />
-          {/* Winter snowflakes with toggle */}
-          <ClientSnowflakes />
           <div className="relative z-10 flex flex-col min-h-screen">
             <Header />
             <main className="flex-grow">


### PR DESCRIPTION
The snowflake feature is winter-only; outside of winter it is a
visual distraction, particularly on mobile. The component files are
preserved so the feature can be re-enabled each winter. Added a
Seasonal Features section to the README documenting how to do so.

https://claude.ai/code/session_01FbVow3h1vCzyzRiqjS9zZb