### PR TITLE
[codex] Add Roll to Eat to projects page

### DIFF
--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -33,14 +33,12 @@ export default function Projects() {
   return (
     <PageLayout title="Projects & Contributions">
       <section className="flex flex-col gap-10 items-center min-h-[40vh]">
-
         {/* --- My Projects --- */}
         <div className="w-full max-w-xl">
           <h2 className="text-sm uppercase tracking-widest text-[var(--text-secondary)] mb-4 pl-1">
             My Projects
           </h2>
           <div className="flex flex-col gap-6">
-
             {/* Portfolio Site */}
             <div className="bg-white/10 rounded-lg shadow-lg border border-[var(--accent-border)] p-6">
               <div className="flex items-center gap-2 flex-wrap mb-2">
@@ -95,9 +93,10 @@ export default function Projects() {
               </div>
               <p className="mb-4 text-base text-[var(--text-secondary)]">
                 A lightweight Windows taskbar widget built in Rust using the Win32 API. Displays
-                daily and weekly work-time progress as colored block bars, updating every 15 seconds.
-                Features configurable work hours, 7 customizable colors, dark/light mode detection
-                via the Windows registry, weekend auto-detection, and a single-instance guard.
+                daily and weekly work-time progress as colored block bars, updating every 15
+                seconds. Features configurable work hours, 7 customizable colors, dark/light mode
+                detection via the Windows registry, weekend auto-detection, and a single-instance
+                guard.
               </p>
               <a
                 href="https://github.com/saucy-tech/work-time-visualizer-rust"
@@ -123,9 +122,9 @@ export default function Projects() {
                 <Tag label="NWC" />
               </div>
               <p className="mb-4 text-base text-[var(--text-secondary)]">
-                A Lightning tipping interface template from ATL BitLab&apos;s workshop, enhanced with
-                @getalby/sdk integration for seamless NWC support. Users can select sats, generate
-                invoices, and tip via Lightning.
+                A Lightning tipping interface template from ATL BitLab&apos;s workshop, enhanced
+                with @getalby/sdk integration for seamless NWC support. Users can select sats,
+                generate invoices, and tip via Lightning.
               </p>
               <div className="flex flex-wrap gap-3">
                 <a
@@ -147,6 +146,45 @@ export default function Projects() {
               </div>
             </div>
 
+            {/* Roll to Eat */}
+            <div className="bg-white/10 rounded-lg shadow-lg border border-[var(--accent-border)] p-6">
+              <div className="flex items-center gap-2 flex-wrap mb-2">
+                <h3 className="text-xl font-semibold">Roll to Eat</h3>
+                <span className="text-xs bg-green-500/80 text-white px-2 py-0.5 rounded-full">
+                  Launched
+                </span>
+              </div>
+              <div className="flex flex-wrap gap-2 mb-3">
+                <Tag label="Next.js" />
+                <Tag label="React" />
+                <Tag label="TypeScript" />
+                <Tag label="Tailwind CSS" />
+              </div>
+              <p className="mb-4 text-base text-[var(--text-secondary)]">
+                A playful dinner-decision app that rolls two d20s to pair a cuisine with a main
+                ingredient. Built with Next.js and React, it supports custom tables saved in the
+                browser, reroll workflows with lockable dice, local roll history, and shareable
+                result pages.
+              </p>
+              <div className="flex flex-wrap gap-3">
+                <a
+                  href="https://github.com/saucy-tech/roll-to-eat"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-block px-4 py-2 bg-[var(--accent)] text-white rounded hover:bg-[var(--accent-dark)] transition"
+                >
+                  GitHub Repo
+                </a>
+                <a
+                  href="https://roll-to-eat.vercel.app/"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-block px-4 py-2 bg-[var(--accent)] text-white rounded hover:bg-[var(--accent-dark)] transition"
+                >
+                  Live Demo
+                </a>
+              </div>
+            </div>
           </div>
         </div>
 
@@ -156,7 +194,6 @@ export default function Projects() {
             Open Source Contributions
           </h2>
           <div className="flex flex-col gap-6">
-
             {/* Abbot */}
             <div className="bg-white/10 rounded-lg shadow-lg border border-[var(--accent-border)] p-6">
               <div className="flex items-center gap-2 flex-wrap mb-2">
@@ -199,8 +236,9 @@ export default function Projects() {
                 <Tag label="Lightning" />
               </div>
               <p className="mb-4 text-base text-[var(--text-secondary)]">
-                Contributor to the Plebnet website, an open-source project for the Plebnet community.
-                Helped improve site features and content for the broader Lightning Network community.
+                Contributor to the Plebnet website, an open-source project for the Plebnet
+                community. Helped improve site features and content for the broader Lightning
+                Network community.
               </p>
               <a
                 href="https://github.com/plebnet-dev/website"
@@ -211,10 +249,8 @@ export default function Projects() {
                 GitHub Repo
               </a>
             </div>
-
           </div>
         </div>
-
       </section>
     </PageLayout>
   );


### PR DESCRIPTION
## Summary
- add `Roll to Eat` to the portfolio projects page
- include both the GitHub repo and live demo links
- keep the change scoped to the existing hardcoded projects section

## Why
`Roll to Eat` is a fun side project worth showing off in the portfolio alongside the rest of the site's personal projects.

## Validation
- `pnpm lint`
- `pnpm test`