### PR TITLE
claude/audit-frontend-xNaBW

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -61,8 +61,9 @@ export const metadata: Metadata = {
     creator: '@Saucy_Tech',
   },
   icons: {
-    icon: [{ url: '/icons/github-logo.svg', type: 'image/svg+xml' }],
-    shortcut: [{ url: '/icons/github-logo.svg', type: 'image/svg+xml' }],
+    icon: [{ url: '/favicon.ico' }],
+    shortcut: [{ url: '/favicon.ico' }],
+    apple: [{ url: '/apple-touch-icon.png', sizes: '180x180' }],
   },
   manifest: '/manifest.json',
 };
@@ -91,7 +92,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
           <ClientGalaxyBackground />
           <div className="relative z-10 flex flex-col min-h-screen">
             <Header />
-            <main className="flex-grow">
+            <main id="main-content" className="flex-grow">
               <div className="container mx-auto max-w-5xl">{children}</div>
             </main>
             <Footer />

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -13,7 +13,6 @@ import { SITE_NAME, SITE_URL, SITE_DESCRIPTION } from '@/utils/constants';
 export default async function Home() {
   const profileData = {
     name: 'Brandon',
-    username: '',
     bio: 'Love Jesus, Explore Ideas, Create Things, Save in Bitcoin',
     imageSrc: '/family-photo.jpeg',
   };
@@ -85,7 +84,7 @@ export default async function Home() {
   };
 
   return (
-    <main className="pt-4 pb-6 px-4 md:px-8 flex flex-col items-center">
+    <div className="pt-4 pb-6 px-4 md:px-8 flex flex-col items-center">
       <script
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
@@ -154,6 +153,6 @@ export default async function Home() {
           </Link>
         </div>
       </div>
-    </main>
+    </div>
   );
 }

--- a/src/components/BlogArchive.tsx
+++ b/src/components/BlogArchive.tsx
@@ -90,9 +90,11 @@ export default function BlogArchive({ posts }: BlogArchiveProps) {
             Browse by type, topic, or scripture passage.
           </div>
 
-          <label className="relative block">
+          <label htmlFor="blog-search" className="relative block">
+            <span className="sr-only">Search posts</span>
             <MagnifyingGlassIcon className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-[var(--text-secondary)]" />
             <input
+              id="blog-search"
               type="search"
               value={query}
               onChange={(event) => setQuery(event.target.value)}

--- a/src/components/PageLayout.tsx
+++ b/src/components/PageLayout.tsx
@@ -19,7 +19,7 @@ export default function PageLayout({
       <div className="container mx-auto px-4 py-8 flex-grow">
         <Link
           href={backHref}
-          className="inline-flex items-center text-[#D4AF37] hover:text-[#D4AF37]/80 transition-colors mb-8"
+          className="inline-flex items-center text-[var(--accent)] hover:opacity-80 transition-opacity mb-8"
         >
           <ArrowLeftIcon className="h-5 w-5 mr-2" />
           {backLabel}

--- a/src/components/Profile.tsx
+++ b/src/components/Profile.tsx
@@ -49,7 +49,7 @@ const Profile: React.FC<ProfileProps> = ({ name, bio, imageSrc }) => {
             fill
             className="object-cover"
             priority
-            sizes="(max-width: 128px) 100vw, 128px"
+            sizes="128px"
             onLoad={handleImageLoad}
             onError={handleImageError}
             quality={85}

--- a/src/components/SubscribeForm.tsx
+++ b/src/components/SubscribeForm.tsx
@@ -25,7 +25,11 @@ export default function SubscribeForm() {
 
   return (
     <form onSubmit={handleSubmit} className="w-full max-w-md mx-auto space-y-3">
+      <label htmlFor="subscribe-email" className="sr-only">
+        Email address
+      </label>
       <input
+        id="subscribe-email"
         type="email"
         required
         placeholder="Your email"

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -1,12 +1,10 @@
-'use client';
-
 import { BaseProps } from '@/types';
 import { cn } from '@/utils/helpers';
 import { SITE_NAME } from '@/utils/constants';
 
 export default function Footer({ className }: BaseProps) {
   const currentYear = new Date().getFullYear();
-  
+
   return (
     <footer className={cn('py-6 transparent', className)}>
       <div className="container mx-auto px-4">
@@ -19,4 +17,3 @@ export default function Footer({ className }: BaseProps) {
     </footer>
   );
 }
-

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import Link from 'next/link';
 
 import { BaseProps } from '@/types';
@@ -9,8 +7,14 @@ import { cn } from '@/utils/helpers';
 export default function Header({ className }: BaseProps) {
   return (
     <header className={cn('py-4 transparent', className)}>
+      <a
+        href="#main-content"
+        className="sr-only focus:not-sr-only focus:absolute focus:z-50 focus:top-4 focus:left-4 focus:rounded focus:bg-[var(--accent)] focus:px-4 focus:py-2 focus:text-sm focus:font-medium focus:text-black"
+      >
+        Skip to content
+      </a>
       <div className="container mx-auto px-4 flex justify-center items-center">
-        <nav className="flex space-x-6 items-center">
+        <nav aria-label="Main navigation" className="flex space-x-6 items-center">
           <Link
             href="/"
             className="text-xl font-bold text-[var(--accent)] hover:opacity-80 transition-opacity"


### PR DESCRIPTION
- Remove nested <main> landmark: page.tsx now uses <div> (layout.tsx owns <main>)
- Add skip-to-content link in Header; convert Header/Footer to server components
- Add visually-hidden labels for email input (SubscribeForm) and search input (BlogArchive)
- Fix favicon config to use favicon.ico/apple-touch-icon.png instead of GitHub logo SVG
- Replace hardcoded #D4AF37 hex with var(--accent) in PageLayout
- Fix Profile image sizes attribute (was wrong media condition); remove unused username prop

https://claude.ai/code/session_016ASdwrB2J2FsBV1Ekkhfyy