### PR TITLE
Add shared site navigation to header and footer

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,7 +4,9 @@ import { headers } from 'next/headers';
 import './globals.css';
 import Header from '@/components/layout/Header';
 import Footer from '@/components/layout/Footer';
+import { getFooterNavItems, getSiteNavItems } from '@/config/site-nav';
 import { SITE_NAME, SITE_DESCRIPTION, SITE_URL } from '@/utils/constants';
+import { getAllPostsMeta } from '@/utils/posts';
 import { APPEARANCE_STORAGE_KEY, THEME_STORAGE_KEY } from '@/utils/theme';
 import ClientGalaxyBackground from '@/components/ClientGalaxyBackground';
 import { Analytics } from '@vercel/analytics/react';
@@ -84,10 +86,14 @@ export const metadata: Metadata = {
 
 export default async function RootLayout({ children }: { children: React.ReactNode }) {
   const nonce = (await headers()).get('x-nonce') ?? undefined;
+  const latestSlug = getAllPostsMeta()[0]?.slug ?? null;
+  const navItems = getSiteNavItems({ latestSlug });
+  const footerNavItems = getFooterNavItems({ latestSlug });
   return (
     <html lang="en" suppressHydrationWarning>
       <head>
         <script
+          suppressHydrationWarning
           {...(nonce ? { nonce } : {})}
           dangerouslySetInnerHTML={{
             __html: `(function(){try{var t=${JSON.stringify(THEME_STORAGE_KEY)};var a=${JSON.stringify(APPEARANCE_STORAGE_KEY)};if(localStorage.getItem(t)==='green')document.documentElement.setAttribute('data-theme','green');if(localStorage.getItem(a)==='light')document.documentElement.setAttribute('data-appearance','light');}catch(e){}})();`,
@@ -101,11 +107,13 @@ export default async function RootLayout({ children }: { children: React.ReactNo
           {/* Client-only animated background */}
           <ClientGalaxyBackground />
           <div className="relative z-10 flex flex-col min-h-screen">
-            <Header />
+            <Header navItems={navItems} />
             <main id="main-content" className="flex-grow">
-              <div className="container mx-auto max-w-[min(100%,80rem)] px-4 sm:px-6">{children}</div>
+              <div className="container mx-auto max-w-[min(100%,80rem)] px-4 sm:px-6">
+                {children}
+              </div>
             </main>
-            <Footer />
+            <Footer navItems={footerNavItems} />
           </div>
         </div>
         <Analytics />

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -114,7 +114,7 @@ export default async function Home() {
           )}
           <LinkCard
             key="blog-home"
-            title="Browse the Blog"
+            title="Writing"
             href="/blog"
             icon={<span className="text-2xl">📚</span>}
             eyebrow="Blog"

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -1,18 +1,23 @@
+import SiteNav from '@/components/layout/SiteNav';
+import type { SiteNavItem } from '@/config/site-nav';
 import { BaseProps } from '@/types';
-import { cn } from '@/utils/helpers';
 import { SITE_NAME } from '@/utils/constants';
+import { cn } from '@/utils/helpers';
 
-export default function Footer({ className }: BaseProps) {
+type FooterProps = BaseProps & {
+  navItems: SiteNavItem[];
+};
+
+export default function Footer({ className, navItems }: FooterProps) {
   const currentYear = new Date().getFullYear();
 
   return (
     <footer className={cn('py-6 transparent', className)}>
-      <div className="container mx-auto px-4">
-        <div className="flex justify-center items-center">
-          <p className="text-[var(--accent)] text-sm opacity-80">
-            &copy; {currentYear} {SITE_NAME}
-          </p>
-        </div>
+      <div className="container mx-auto px-4 flex flex-col items-center gap-4">
+        <SiteNav items={navItems} ariaLabel="Footer" />
+        <p className="text-[var(--accent)] text-sm opacity-80">
+          &copy; {currentYear} {SITE_NAME}
+        </p>
       </div>
     </footer>
   );

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,12 +1,18 @@
 import Link from 'next/link';
 
 import AppearanceToggle from '@/components/AppearanceToggle';
+import SiteNav from '@/components/layout/SiteNav';
 import ThemeToggle from '@/components/ThemeToggle';
+import type { SiteNavItem } from '@/config/site-nav';
 import { BaseProps } from '@/types';
 import { SITE_NAME } from '@/utils/constants';
 import { cn } from '@/utils/helpers';
 
-export default function Header({ className }: BaseProps) {
+type HeaderProps = BaseProps & {
+  navItems: SiteNavItem[];
+};
+
+export default function Header({ className, navItems }: HeaderProps) {
   return (
     <header className={cn('py-4 transparent', className)}>
       <a
@@ -15,21 +21,24 @@ export default function Header({ className }: BaseProps) {
       >
         Skip to content
       </a>
-      <div className="container mx-auto grid grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)] items-center gap-3 px-4">
-        <div className="flex min-w-0 justify-start">
-          <ThemeToggle />
+      <div className="container mx-auto flex flex-col gap-3 px-4">
+        <div className="grid grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)] items-center gap-3">
+          <div className="flex min-w-0 justify-start">
+            <ThemeToggle />
+          </div>
+          <nav aria-label="Main navigation" className="flex justify-center">
+            <Link
+              href="/"
+              className="text-center text-xl font-bold text-[var(--accent)] hover:opacity-80 transition-opacity"
+            >
+              {SITE_NAME}
+            </Link>
+          </nav>
+          <div className="flex min-w-0 justify-end">
+            <AppearanceToggle />
+          </div>
         </div>
-        <nav aria-label="Main navigation" className="flex justify-center">
-          <Link
-            href="/"
-            className="text-center text-xl font-bold text-[var(--accent)] hover:opacity-80 transition-opacity"
-          >
-            {SITE_NAME}
-          </Link>
-        </nav>
-        <div className="flex min-w-0 justify-end">
-          <AppearanceToggle />
-        </div>
+        <SiteNav items={navItems} ariaLabel="Site sections" />
       </div>
     </header>
   );

--- a/src/components/layout/SiteNav.tsx
+++ b/src/components/layout/SiteNav.tsx
@@ -1,0 +1,55 @@
+'use client';
+
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+
+import { type SiteNavItem, isNavActive } from '@/config/site-nav';
+import { cn } from '@/utils/helpers';
+
+const linkClass =
+  'text-[var(--text-secondary)] hover:text-[var(--accent)] transition-colors focus:outline-none focus:ring-2 focus:ring-[var(--focus-ring)] focus:ring-offset-2 focus:ring-offset-[var(--background)] rounded-sm';
+
+const activeClass = 'text-[var(--accent)] font-medium';
+
+type SiteNavProps = {
+  items: SiteNavItem[];
+  className?: string;
+  listClassName?: string;
+  /** Landmark label for header vs footer navigation. */
+  ariaLabel?: string;
+};
+
+export default function SiteNav({
+  items,
+  className,
+  listClassName,
+  ariaLabel = 'Site sections',
+}: SiteNavProps) {
+  const pathname = usePathname() ?? '';
+
+  return (
+    <nav aria-label={ariaLabel} className={className}>
+      <ul
+        className={cn(
+          'flex flex-wrap justify-center gap-x-4 gap-y-2 text-sm list-none m-0 p-0',
+          listClassName
+        )}
+      >
+        {items.map((item) => {
+          const active = isNavActive(pathname, item, items);
+          return (
+            <li key={`${item.href}-${item.label}`}>
+              <Link
+                href={item.href}
+                className={cn(linkClass, active && activeClass)}
+                aria-current={active ? 'page' : undefined}
+              >
+                {item.label}
+              </Link>
+            </li>
+          );
+        })}
+      </ul>
+    </nav>
+  );
+}

--- a/src/config/site-nav.ts
+++ b/src/config/site-nav.ts
@@ -1,0 +1,44 @@
+export type NavMatch = 'exact' | 'prefix';
+
+export type SiteNavItem = {
+  href: string;
+  label: string;
+  match: NavMatch;
+};
+
+/** Shown in the footer after primary nav items (RSS, utility links). */
+export const FOOTER_EXTRA_NAV: SiteNavItem[] = [
+  { href: '/links', label: 'Links', match: 'exact' },
+  { href: '/rss.xml', label: 'RSS', match: 'exact' },
+];
+
+export function isNavActive(pathname: string, item: SiteNavItem, allItems: SiteNavItem[]): boolean {
+  if (item.match === 'exact') {
+    return pathname === item.href;
+  }
+  const hasExactForPath = allItems.some((i) => i.match === 'exact' && i.href === pathname);
+  if (hasExactForPath) {
+    return false;
+  }
+  return pathname === item.href || pathname.startsWith(`${item.href}/`);
+}
+
+export function getSiteNavItems({ latestSlug }: { latestSlug: string | null }): SiteNavItem[] {
+  const items: SiteNavItem[] = [{ href: '/blog', label: 'Writing', match: 'prefix' }];
+  if (latestSlug) {
+    items.push({ href: `/blog/${latestSlug}`, label: 'Latest', match: 'exact' });
+  }
+  items.push(
+    { href: '/projects', label: 'Projects', match: 'exact' },
+    { href: '/field-notes', label: 'Field notes', match: 'exact' },
+    { href: '/bitcoin', label: 'Bitcoin', match: 'exact' },
+    { href: '/daily-word', label: 'Daily Word', match: 'exact' },
+    { href: '/talks', label: 'Talks', match: 'exact' },
+    { href: '/support', label: 'Support', match: 'exact' }
+  );
+  return items;
+}
+
+export function getFooterNavItems({ latestSlug }: { latestSlug: string | null }): SiteNavItem[] {
+  return [...getSiteNavItems({ latestSlug }), ...FOOTER_EXTRA_NAV];
+}


### PR DESCRIPTION
## Summary
- Added a shared navigation config to centralize header/footer links and active-state matching.
- Updated the header to show primary site sections below the title and keep theme/appearance controls in place.
- Updated the footer to reuse the same navigation pattern and include Links and RSS utility items.
- Renamed the homepage blog card from “Browse the Blog” to “Writing” for consistency with the new nav label.

## Testing
- Not run (not requested).
- Reviewed the diff for header/footer layout changes and nav item wiring.
- Verified the new navigation component uses pathname-based active state and `aria-current` for the current page.