### PR TITLE
Defer galaxy boot and add new devotion post

### DIFF
--- a/src/components/ClientGalaxyBackground.tsx
+++ b/src/components/ClientGalaxyBackground.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import dynamic from 'next/dynamic';
-import { useSyncExternalStore } from 'react';
+import { useEffect, useState, useSyncExternalStore } from 'react';
 import { usePathname } from 'next/navigation';
 
 const GalaxyBackground = dynamic(() => import('@/components/GalaxyBackground'), {
@@ -30,6 +30,7 @@ function getServerLightSnapshot(): boolean {
 export default function ClientGalaxyBackground() {
   const pathname = usePathname();
   const isLight = useSyncExternalStore(subscribeAppearance, isLightMode, getServerLightSnapshot);
+  const [canMountGalaxy, setCanMountGalaxy] = useState(false);
   const themeEpoch = useSyncExternalStore(
     subscribeAppearance,
     () =>
@@ -37,13 +38,56 @@ export default function ClientGalaxyBackground() {
     () => '0'
   );
 
-  if (pathname !== '/') {
-    return null;
-  }
+  useEffect(() => {
+    if (pathname !== '/' || isLight) {
+      setCanMountGalaxy(false);
+      return;
+    }
 
-  if (isLight) {
-    return null;
-  }
+    let cancelled = false;
+    let idleCallbackId: number | null = null;
+    let timeoutId: number | null = null;
 
-  return <GalaxyBackground key={themeEpoch} />;
+    const mountWhenIdle = () => {
+      if (typeof window.requestIdleCallback === 'function') {
+        idleCallbackId = window.requestIdleCallback(
+          () => {
+            if (!cancelled) {
+              setCanMountGalaxy(true);
+            }
+          },
+          { timeout: 1200 }
+        );
+        return;
+      }
+
+      timeoutId = window.setTimeout(() => {
+        if (!cancelled) {
+          setCanMountGalaxy(true);
+        }
+      }, 250);
+    };
+
+    mountWhenIdle();
+
+    return () => {
+      cancelled = true;
+
+      if (idleCallbackId !== null && typeof window.cancelIdleCallback === 'function') {
+        window.cancelIdleCallback(idleCallbackId);
+      }
+
+      if (timeoutId !== null) {
+        window.clearTimeout(timeoutId);
+      }
+    };
+  }, [isLight, pathname]);
+
+  if (pathname !== '/') return null;
+
+  return (
+    <div className="fixed inset-0 pointer-events-none" aria-hidden="true">
+      {!isLight && canMountGalaxy ? <GalaxyBackground key={themeEpoch} /> : null}
+    </div>
+  );
 }

--- a/src/components/ClientGalaxyBackground.tsx
+++ b/src/components/ClientGalaxyBackground.tsx
@@ -39,8 +39,7 @@ export default function ClientGalaxyBackground() {
   );
 
   useEffect(() => {
-    if (pathname !== '/' || isLight) {
-      setCanMountGalaxy(false);
+    if (pathname !== '/' || isLight || canMountGalaxy) {
       return;
     }
 
@@ -81,7 +80,7 @@ export default function ClientGalaxyBackground() {
         window.clearTimeout(timeoutId);
       }
     };
-  }, [isLight, pathname]);
+  }, [canMountGalaxy, isLight, pathname]);
 
   if (pathname !== '/') return null;
 

--- a/src/components/GalaxyBackground.test.tsx
+++ b/src/components/GalaxyBackground.test.tsx
@@ -19,6 +19,7 @@ describe('GalaxyBackground', () => {
 
   beforeEach(() => {
     let nextFrameId = 1;
+    let nextIdleId = 1;
 
     Object.defineProperty(window, 'requestAnimationFrame', {
       configurable: true,
@@ -27,6 +28,24 @@ describe('GalaxyBackground', () => {
     });
 
     Object.defineProperty(window, 'cancelAnimationFrame', {
+      configurable: true,
+      writable: true,
+      value: jest.fn(),
+    });
+
+    Object.defineProperty(window, 'requestIdleCallback', {
+      configurable: true,
+      writable: true,
+      value: jest.fn((cb: IdleRequestCallback) => {
+        cb({
+          didTimeout: false,
+          timeRemaining: () => 10,
+        } as IdleDeadline);
+        return nextIdleId++;
+      }),
+    });
+
+    Object.defineProperty(window, 'cancelIdleCallback', {
       configurable: true,
       writable: true,
       value: jest.fn(),

--- a/src/components/GalaxyBackground.tsx
+++ b/src/components/GalaxyBackground.tsx
@@ -238,7 +238,7 @@ const GalaxyBackground: React.FC<GalaxyBackgroundProps> = ({ children }) => {
     <>
       <canvas
         ref={canvasRef}
-        className="absolute inset-0 w-full h-full pointer-events-none"
+        className="fixed inset-0 w-full h-full pointer-events-none"
         style={{ zIndex: 0 }}
       />
       {children}

--- a/src/components/GalaxyBackground.tsx
+++ b/src/components/GalaxyBackground.tsx
@@ -34,176 +34,203 @@ const GalaxyBackground: React.FC<GalaxyBackgroundProps> = ({ children }) => {
   }, []);
 
   useEffect(() => {
-    // Retrieve CSS variables or fallback to defaults
-    const computedStyle = getComputedStyle(document.documentElement);
-    const rawBg = computedStyle.getPropertyValue('--background').trim();
-    const rawAccent = computedStyle.getPropertyValue('--accent').trim();
-    const background = rawBg || '#07251F';
-    const accent = rawAccent || '#f7931a';
+    let cancelled = false;
+    let idleCallbackId: number | null = null;
+    let timeoutId: number | null = null;
+    let cleanupAnimation: (() => void) | null = null;
 
-    // Helper to convert hex color to RGB
-    const hexToRgb = (hex: string) => {
-      let sanitizedHex = hex.replace('#', '');
-      if (sanitizedHex.length === 3) {
-        sanitizedHex = sanitizedHex
-          .split('')
-          .map((c) => c + c)
-          .join('');
-      }
-      const intVal = parseInt(sanitizedHex, 16);
-      return {
-        r: (intVal >> 16) & 255,
-        g: (intVal >> 8) & 255,
-        b: intVal & 255,
-      };
-    };
-    const bgRgb = hexToRgb(background);
-    const accentRgb = hexToRgb(accent);
+    const initializeGalaxy = () => {
+      const canvas = canvasRef.current;
+      if (!canvas || cancelled) return;
 
-    const canvas = canvasRef.current;
-    if (!canvas) return;
+      // Retrieve CSS variables or fallback to defaults
+      const computedStyle = getComputedStyle(document.documentElement);
+      const rawBg = computedStyle.getPropertyValue('--background').trim();
+      const rawAccent = computedStyle.getPropertyValue('--accent').trim();
+      const background = rawBg || '#07251F';
+      const accent = rawAccent || '#f7931a';
 
-    const ctx = canvas.getContext('2d', { alpha: true });
-    if (!ctx) return;
-
-    // Star properties
-    const stars: {
-      x: number;
-      y: number;
-      size: number;
-      brightness: number;
-      speed: number;
-      color: number; // 0-1 for color variation
-    }[] = [];
-    const numStars = 150; // Reduced star count for better performance
-
-    const populateStars = () => {
-      stars.length = 0;
-
-      for (let i = 0; i < numStars; i++) {
-        stars.push({
-          x: Math.random() * canvas.width,
-          y: Math.random() * canvas.height,
-          size: Math.random() * 2,
-          brightness: Math.random(),
-          speed: 0.005 + Math.random() * 0.02,
-          color: Math.random(),
-        });
-      }
-    };
-
-    const setCanvasSize = () => {
-      canvas.width = window.innerWidth;
-      canvas.height = window.innerHeight;
-    };
-
-    const drawBackground = (opacity = 1) => {
-      ctx.fillStyle =
-        opacity === 1
-          ? `rgb(${bgRgb.r}, ${bgRgb.g}, ${bgRgb.b})`
-          : `rgba(${bgRgb.r}, ${bgRgb.g}, ${bgRgb.b}, ${opacity})`;
-      ctx.fillRect(0, 0, canvas.width, canvas.height);
-    };
-
-    const drawStars = () => {
-      stars.forEach((star) => {
-        const opacity = 0.2 + Math.sin(time * 2 + star.brightness * 10) * 0.2;
-
-        ctx.fillStyle = `rgba(${accentRgb.r}, ${accentRgb.g}, ${accentRgb.b}, ${opacity})`;
-        ctx.beginPath();
-        ctx.arc(star.x, star.y, star.size, 0, Math.PI * 2);
-        ctx.fill();
-
-        if (star.size > 1.5) {
-          ctx.beginPath();
-          ctx.arc(star.x, star.y, star.size * 2, 0, Math.PI * 2);
-          const gradient = ctx.createRadialGradient(
-            star.x,
-            star.y,
-            0,
-            star.x,
-            star.y,
-            star.size * 3
-          );
-          gradient.addColorStop(0, `rgba(${accentRgb.r}, ${accentRgb.g}, ${accentRgb.b}, 0.125)`);
-          gradient.addColorStop(1, `rgba(${accentRgb.r}, ${accentRgb.g}, ${accentRgb.b}, 0)`);
-          ctx.fillStyle = gradient;
-          ctx.fill();
+      // Helper to convert hex color to RGB
+      const hexToRgb = (hex: string) => {
+        let sanitizedHex = hex.replace('#', '');
+        if (sanitizedHex.length === 3) {
+          sanitizedHex = sanitizedHex
+            .split('')
+            .map((c) => c + c)
+            .join('');
         }
-      });
-    };
+        const intVal = parseInt(sanitizedHex, 16);
+        return {
+          r: (intVal >> 16) & 255,
+          g: (intVal >> 8) & 255,
+          b: intVal & 255,
+        };
+      };
+      const bgRgb = hexToRgb(background);
+      const accentRgb = hexToRgb(accent);
 
-    const updateStars = () => {
-      stars.forEach((star) => {
-        star.y = (star.y + star.speed) % canvas.height;
-        star.x += Math.sin(time + star.brightness) * 0.1;
-        star.x = (star.x + canvas.width) % canvas.width;
-      });
-    };
+      const ctx = canvas.getContext('2d', { alpha: true });
+      if (!ctx) return;
 
-    const drawStaticFrame = () => {
-      drawBackground();
-      drawStars();
-    };
+      // Star properties
+      const stars: {
+        x: number;
+        y: number;
+        size: number;
+        brightness: number;
+        speed: number;
+        color: number; // 0-1 for color variation
+      }[] = [];
+      const numStars = 150; // Reduced star count for better performance
 
-    const handleResize = () => {
+      const populateStars = () => {
+        stars.length = 0;
+
+        for (let i = 0; i < numStars; i++) {
+          stars.push({
+            x: Math.random() * canvas.width,
+            y: Math.random() * canvas.height,
+            size: Math.random() * 2,
+            brightness: Math.random(),
+            speed: 0.005 + Math.random() * 0.02,
+            color: Math.random(),
+          });
+        }
+      };
+
+      const setCanvasSize = () => {
+        canvas.width = window.innerWidth;
+        canvas.height = window.innerHeight;
+      };
+
+      const drawBackground = (opacity = 1) => {
+        ctx.fillStyle =
+          opacity === 1
+            ? `rgb(${bgRgb.r}, ${bgRgb.g}, ${bgRgb.b})`
+            : `rgba(${bgRgb.r}, ${bgRgb.g}, ${bgRgb.b}, ${opacity})`;
+        ctx.fillRect(0, 0, canvas.width, canvas.height);
+      };
+
+      const drawStars = () => {
+        stars.forEach((star) => {
+          const opacity = 0.2 + Math.sin(time * 2 + star.brightness * 10) * 0.2;
+
+          ctx.fillStyle = `rgba(${accentRgb.r}, ${accentRgb.g}, ${accentRgb.b}, ${opacity})`;
+          ctx.beginPath();
+          ctx.arc(star.x, star.y, star.size, 0, Math.PI * 2);
+          ctx.fill();
+
+          if (star.size > 1.5) {
+            ctx.beginPath();
+            ctx.arc(star.x, star.y, star.size * 2, 0, Math.PI * 2);
+            const gradient = ctx.createRadialGradient(
+              star.x,
+              star.y,
+              0,
+              star.x,
+              star.y,
+              star.size * 3
+            );
+            gradient.addColorStop(0, `rgba(${accentRgb.r}, ${accentRgb.g}, ${accentRgb.b}, 0.125)`);
+            gradient.addColorStop(1, `rgba(${accentRgb.r}, ${accentRgb.g}, ${accentRgb.b}, 0)`);
+            ctx.fillStyle = gradient;
+            ctx.fill();
+          }
+        });
+      };
+
+      const updateStars = () => {
+        stars.forEach((star) => {
+          star.y = (star.y + star.speed) % canvas.height;
+          star.x += Math.sin(time + star.brightness) * 0.1;
+          star.x = (star.x + canvas.width) % canvas.width;
+        });
+      };
+
+      const drawStaticFrame = () => {
+        drawBackground();
+        drawStars();
+      };
+
+      const handleResize = () => {
+        setCanvasSize();
+        populateStars();
+
+        if (reducedMotion) {
+          drawStaticFrame();
+          return;
+        }
+
+        drawBackground();
+        drawStars();
+      };
+
       setCanvasSize();
       populateStars();
+      window.addEventListener('resize', handleResize);
 
-      if (reducedMotion) {
-        drawStaticFrame();
-        return;
-      }
+      let animationFrameId: number | null = null;
+      let time = 0;
+      let isPageVisible = !document.hidden;
+
+      const animate = () => {
+        if (!isPageVisible) {
+          animationFrameId = window.requestAnimationFrame(animate);
+          return;
+        }
+
+        time += 0.002; // Slower time increment for smoother animation
+
+        drawBackground(0.5);
+        drawStars();
+        updateStars();
+
+        animationFrameId = window.requestAnimationFrame(animate);
+      };
 
       drawBackground();
       drawStars();
-    };
 
-    setCanvasSize();
-    populateStars();
-    window.addEventListener('resize', handleResize);
+      const handleVisibilityChange = () => {
+        isPageVisible = !document.hidden;
+        if (isPageVisible && reducedMotion) {
+          drawStaticFrame();
+        }
+      };
+      document.addEventListener('visibilitychange', handleVisibilityChange);
 
-    let animationFrameId: number | null = null;
-    let time = 0;
-    let isPageVisible = !document.hidden;
-
-    const animate = () => {
-      if (!isPageVisible) {
+      if (!reducedMotion) {
         animationFrameId = window.requestAnimationFrame(animate);
-        return;
       }
 
-      time += 0.002; // Slower time increment for smoother animation
+      cleanupAnimation = () => {
+        window.removeEventListener('resize', handleResize);
+        document.removeEventListener('visibilitychange', handleVisibilityChange);
 
-      drawBackground(0.5);
-      drawStars();
-      updateStars();
-
-      animationFrameId = window.requestAnimationFrame(animate);
+        if (animationFrameId !== null) {
+          window.cancelAnimationFrame(animationFrameId);
+        }
+      };
     };
 
-    drawBackground();
-    drawStars();
-
-    const handleVisibilityChange = () => {
-      isPageVisible = !document.hidden;
-      if (isPageVisible && reducedMotion) {
-        drawStaticFrame();
-      }
-    };
-    document.addEventListener('visibilitychange', handleVisibilityChange);
-
-    if (!reducedMotion) {
-      animationFrameId = window.requestAnimationFrame(animate);
+    if (typeof window.requestIdleCallback === 'function') {
+      idleCallbackId = window.requestIdleCallback(initializeGalaxy, { timeout: 1200 });
+    } else {
+      timeoutId = window.setTimeout(initializeGalaxy, 250);
     }
 
     return () => {
-      window.removeEventListener('resize', handleResize);
-      document.removeEventListener('visibilitychange', handleVisibilityChange);
+      cancelled = true;
 
-      if (animationFrameId !== null) {
-        window.cancelAnimationFrame(animationFrameId);
+      if (idleCallbackId !== null && typeof window.cancelIdleCallback === 'function') {
+        window.cancelIdleCallback(idleCallbackId);
       }
+
+      if (timeoutId !== null) {
+        window.clearTimeout(timeoutId);
+      }
+
+      cleanupAnimation?.();
     };
   }, [reducedMotion]);
 
@@ -211,7 +238,7 @@ const GalaxyBackground: React.FC<GalaxyBackgroundProps> = ({ children }) => {
     <>
       <canvas
         ref={canvasRef}
-        className="fixed inset-0 w-full h-full pointer-events-none"
+        className="absolute inset-0 w-full h-full pointer-events-none"
         style={{ zIndex: 0 }}
       />
       {children}

--- a/src/components/LinkCard.tsx
+++ b/src/components/LinkCard.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import { ArrowRightIcon, ArrowTopRightOnSquareIcon } from '@heroicons/react/24/outline';
 import Image from 'next/image';
 import Link from 'next/link';

--- a/src/components/Profile.tsx
+++ b/src/components/Profile.tsx
@@ -1,7 +1,4 @@
-'use client';
-
 import Image from 'next/image';
-import { useState } from 'react';
 
 interface ProfileProps {
   name: string;
@@ -10,41 +7,18 @@ interface ProfileProps {
 }
 
 const Profile: React.FC<ProfileProps> = ({ name, bio, imageSrc }) => {
-  const [imageError, setImageError] = useState(false);
-  const [imageLoading, setImageLoading] = useState(true);
-
-  const handleImageError = () => {
-    setImageError(true);
-    setImageLoading(false);
-  };
-
-  const handleImageLoad = () => {
-    setImageLoading(false);
-  };
-
   return (
     <div className="flex flex-col items-center space-y-4 w-full mx-auto px-2 mb-4">
       <div className="relative w-32 h-32 rounded-full overflow-hidden border-4 border-[var(--accent)] shadow-xl transition-transform duration-200 hover:scale-105 active:scale-95">
-        {imageLoading && (
-          <div className="absolute inset-0 bg-gray-200 animate-pulse rounded-full" />
-        )}
-        {imageError ? (
-          <div className="w-full h-full bg-gradient-to-br from-blue-400 to-purple-600 flex items-center justify-center">
-            <span className="text-white text-4xl font-bold">{name.charAt(0).toUpperCase()}</span>
-          </div>
-        ) : (
-          <Image
-            src={imageSrc}
-            alt={`${name}'s profile photo`}
-            fill
-            className="object-cover"
-            priority
-            sizes="128px"
-            onLoad={handleImageLoad}
-            onError={handleImageError}
-            quality={85}
-          />
-        )}
+        <Image
+          src={imageSrc}
+          alt={`${name}'s profile photo`}
+          fill
+          className="object-cover"
+          priority
+          sizes="128px"
+          quality={75}
+        />
       </div>
 
       <div className="text-center w-full">

--- a/src/posts/2026-04-23-loose-him-and-let-him-go.mdx
+++ b/src/posts/2026-04-23-loose-him-and-let-him-go.mdx
@@ -1,0 +1,39 @@
+---
+title: 'Loose Him and Let Him Go'
+date: '2026-04-23'
+excerpt: 'Jesus raised Lazarus from the dead — then told the crowd to unwrap him. The resurrection was only the beginning of the freedom.'
+category: 'Daily Word'
+series: 'The God Who Arrives When It''s Already Too Late'
+tags:
+  - 'John 11'
+  - 'Resurrection'
+  - 'Freedom'
+  - 'Faith'
+  - 'Power'
+---
+
+> And when he thus had spoken, he cried with a loud voice, Lazarus, come forth. And he that was dead came forth, bound hand and foot with graveclothes: and his face was bound about with a napkin. Jesus saith unto them, Loose him, and let him go. — John 11:43–44 (KJV)
+
+## The Stone Rolls Away
+
+Four days. The crowd was there. The smell was there. Martha had already protested — "Lord, by this time he stinketh." And Jesus did it anyway. He prayed out loud, not for His own benefit, but so the crowd would understand whose power was about to move. Then He shouted into a tomb.
+
+Lazarus came out. Still wrapped in grave clothes. Still bound. But alive.
+
+There are two miracles in this passage, and it's easy to miss the second one. The first is the resurrection. The second comes right after: Jesus turns to the crowd and says, "Loose him, and let him go." He didn't raise Lazarus back to life just to leave him hobbled. He called him out of death and then set him free.
+
+## Called Forth
+
+The "Lazarus moments" are more common than we think — not physical death usually, but the death of a marriage that seemed finished, a friendship gone cold for years, a version of yourself you quietly gave up on. The places you stopped believing could live again.
+
+What's remarkable about Jesus calling into that tomb is that He didn't wait for it to smell better. He didn't ask Lazarus to demonstrate some faith first, didn't ask Mary and Martha to clean the situation up. He called, and death had to obey.
+
+The voice that raised a dead man can reach whatever you've buried.
+
+## Wrapped but Walking
+
+The scene doesn't end with Lazarus walking out. It ends with Jesus instructing the people around him to unwrap him. There's something in that worth sitting with. Some things God raises back to life need community to finish the work of freedom. Coming forth is one thing. Actually walking in open air takes help.
+
+What grave clothes are still on you? What part of you came back to life, but nobody's helped you get free yet?
+
+Jesus is calling something forth today. Not a future promise — a present-tense command. Come forth. And when you do, He is not going to leave you wrapped up. The same voice that opened the tomb is the one saying, "Loose him, and let him go."


### PR DESCRIPTION
## Summary
- Defer homepage galaxy background initialization until idle time to reduce initial render work on the landing page.
- Simplify the profile card and link card components by removing client-only state that is no longer needed.
- Add the new Daily Word post, “Loose Him and Let Him Go.”
- Update galaxy background tests to cover idle-callback behavior.

## Testing
- Not run (changes reviewed from diff only).
- Added/updated test coverage for `requestIdleCallback` and `cancelIdleCallback` handling in `GalaxyBackground.test.tsx`.