### PR TITLE
Improve keyboard focus and form feedback accessibility

### DIFF
--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -108,7 +108,7 @@ export default async function PostPage({ params }: PostPageProps) {
             {post.series && (
               <Link
                 href={`/blog/series/${seriesSlug(post.series)}`}
-                className="rounded-full border border-white/10 bg-black/10 px-3 py-1 text-xs text-[var(--text-secondary)] transition hover:border-[var(--accent-border)] hover:text-[var(--accent)]"
+                className="a11y-focus-ring rounded-full border border-white/10 bg-black/10 px-3 py-1 text-xs text-[var(--text-secondary)] transition hover:border-[var(--accent-border)] hover:text-[var(--accent)]"
               >
                 {post.series}
               </Link>
@@ -135,7 +135,7 @@ export default async function PostPage({ params }: PostPageProps) {
           )}
         </section>
 
-        <article className="prose prose-invert prose-p:text-[1.05rem] prose-p:leading-8 prose-headings:scroll-mt-24 prose-headings:font-semibold prose-headings:text-[var(--text-primary)] prose-h2:mt-12 prose-h2:border-t prose-h2:border-white/10 prose-h2:pt-8 prose-h2:text-2xl prose-h3:mt-10 prose-h3:text-xl prose-a:text-[var(--accent)] prose-a:no-underline hover:prose-a:text-[var(--text-primary)] prose-strong:text-[var(--text-primary)] prose-blockquote:rounded-2xl prose-blockquote:border-l-4 prose-blockquote:border-[var(--accent)] prose-blockquote:bg-white/[0.04] prose-blockquote:px-6 prose-blockquote:py-4 prose-blockquote:text-[var(--text-primary)] prose-hr:border-white/10 prose-img:rounded-3xl prose-img:border prose-img:border-white/10 prose-img:shadow-[0_18px_40px_rgba(0,0,0,0.25)] prose-figcaption:text-sm prose-figcaption:text-[var(--text-secondary)] max-w-none">
+        <article className="prose prose-invert prose-p:text-[1.05rem] prose-p:leading-8 prose-headings:scroll-mt-24 prose-headings:font-semibold prose-headings:text-[var(--text-primary)] prose-h2:mt-12 prose-h2:border-t prose-h2:border-white/10 prose-h2:pt-8 prose-h2:text-2xl prose-h3:mt-10 prose-h3:text-xl prose-a:text-[var(--accent)] prose-a:no-underline prose-a:decoration-[0.1em] prose-a:underline-offset-[0.2em] hover:prose-a:text-[var(--text-primary)] prose-a:focus-visible:rounded-sm prose-a:focus-visible:outline-none prose-a:focus-visible:ring-2 prose-a:focus-visible:ring-[var(--focus-ring)] prose-a:focus-visible:ring-offset-2 prose-a:focus-visible:ring-offset-[var(--background)] prose-strong:text-[var(--text-primary)] prose-blockquote:rounded-2xl prose-blockquote:border-l-4 prose-blockquote:border-[var(--accent)] prose-blockquote:bg-white/[0.04] prose-blockquote:px-6 prose-blockquote:py-4 prose-blockquote:text-[var(--text-primary)] prose-hr:border-white/10 prose-img:rounded-3xl prose-img:border prose-img:border-white/10 prose-img:shadow-[0_18px_40px_rgba(0,0,0,0.25)] prose-figcaption:text-sm prose-figcaption:text-[var(--text-secondary)] max-w-none">
           <MDXRemote source={post.content} />
         </article>
 
@@ -158,7 +158,7 @@ export default async function PostPage({ params }: PostPageProps) {
               </div>
               <Link
                 href="/blog"
-                className="text-sm font-medium text-[var(--accent)] transition hover:text-[var(--text-primary)]"
+                className="a11y-focus-ring rounded-sm text-sm font-medium text-[var(--accent)] transition hover:text-[var(--text-primary)]"
               >
                 Browse all posts
               </Link>
@@ -169,7 +169,7 @@ export default async function PostPage({ params }: PostPageProps) {
                 <Link
                   key={relatedPost.slug}
                   href={`/blog/${relatedPost.slug}`}
-                  className="group rounded-3xl border border-[var(--accent-border)] bg-black/10 p-5 transition hover:border-[var(--accent)] hover:bg-[var(--accent-transparent)]"
+                  className="a11y-focus-ring group rounded-3xl border border-[var(--accent-border)] bg-black/10 p-5 transition hover:border-[var(--accent)] hover:bg-[var(--accent-transparent)]"
                 >
                   <p className="text-xs uppercase tracking-[0.18em] text-[var(--accent)]">
                     {formatPostDate(relatedPost.date)}

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -54,13 +54,13 @@ export default function BlogIndex() {
           <div className="mt-6 flex flex-wrap gap-3">
             <a
               href="#library"
-              className="rounded-full bg-[var(--accent)] px-5 py-2.5 text-sm font-medium text-[var(--on-accent)] transition hover:brightness-110"
+              className="a11y-focus-ring rounded-full bg-[var(--accent)] px-5 py-2.5 text-sm font-medium text-[var(--on-accent)] transition hover:brightness-110"
             >
               Browse the library
             </a>
             <a
               href="#daily-word"
-              className="rounded-full border border-[var(--accent-border)] px-5 py-2.5 text-sm font-medium text-[var(--text-primary)] transition hover:border-[var(--accent)] hover:bg-[var(--accent-transparent)]"
+              className="a11y-focus-ring rounded-full border border-[var(--accent-border)] px-5 py-2.5 text-sm font-medium text-[var(--text-primary)] transition hover:border-[var(--accent)] hover:bg-[var(--accent-transparent)]"
             >
               Subscribe to The Daily Word
             </a>
@@ -94,7 +94,7 @@ export default function BlogIndex() {
 
             <Link
               href={`/blog/${latest.slug}`}
-              className="mt-5 inline-flex text-sm font-medium text-[var(--accent)] transition hover:text-[var(--text-primary)]"
+              className="a11y-focus-ring mt-5 inline-flex rounded-sm text-sm font-medium text-[var(--accent)] transition hover:text-[var(--text-primary)]"
             >
               Read the latest article →
             </Link>
@@ -137,7 +137,7 @@ export default function BlogIndex() {
               {category.href && (
                 <Link
                   href={category.href}
-                  className="inline-flex text-sm font-medium text-[var(--accent)] transition hover:text-[var(--text-primary)]"
+                  className="a11y-focus-ring inline-flex rounded-sm text-sm font-medium text-[var(--accent)] transition hover:text-[var(--text-primary)]"
                 >
                   Visit the Daily Word →
                 </Link>
@@ -145,7 +145,7 @@ export default function BlogIndex() {
               {category.latest && (
                 <Link
                   href={`/blog/${category.latest.slug}`}
-                  className="inline-flex text-sm font-medium text-[var(--accent)] transition hover:text-[var(--text-primary)]"
+                  className="a11y-focus-ring inline-flex rounded-sm text-sm font-medium text-[var(--accent)] transition hover:text-[var(--text-primary)]"
                 >
                   Latest: {category.latest.title}
                 </Link>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -189,6 +189,10 @@ html[data-appearance='light'] article.prose a:hover {
 }
 
 @layer utilities {
+  .a11y-focus-ring {
+    @apply focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--focus-ring)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--background)];
+  }
+
   .section-spacing > * + * {
     margin-top: 3rem;
   }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -163,7 +163,10 @@ export default async function Home() {
         </div>
 
         <div className="text-center text-sm">
-          <Link href="/support" className="text-[var(--accent)] transition hover:text-white">
+          <Link
+            href="/support"
+            className="a11y-focus-ring rounded-sm text-[var(--accent)] transition hover:text-white"
+          >
             Support my work
           </Link>
         </div>

--- a/src/components/LinkCard.tsx
+++ b/src/components/LinkCard.tsx
@@ -64,14 +64,14 @@ const LinkCard: React.FC<LinkCardProps> = ({
               {eyebrow}
             </p>
           )}
-          <h3
+          <h2
             className={cn(
               'break-words text-sm font-semibold leading-snug text-[var(--text-primary)] sm:text-base',
               eyebrow ? 'mt-2' : ''
             )}
           >
             {cardTitle || title}
-          </h3>
+          </h2>
           {meta && <p className="mt-2 text-xs text-[var(--text-secondary)]">{meta}</p>}
           {description && (
             <p className="mt-3 text-sm leading-relaxed text-[var(--text-secondary)]">
@@ -104,14 +104,19 @@ const LinkCard: React.FC<LinkCardProps> = ({
 
   if (isExternal) {
     return (
-      <a href={href} target="_blank" rel="noopener noreferrer" className="block h-full w-full">
+      <a
+        href={href}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="a11y-focus-ring block h-full w-full rounded-2xl"
+      >
         {cardContent}
       </a>
     );
   }
 
   return (
-    <Link href={href} className="block h-full w-full">
+    <Link href={href} className="a11y-focus-ring block h-full w-full rounded-2xl">
       {cardContent}
     </Link>
   );

--- a/src/components/PageLayout.tsx
+++ b/src/components/PageLayout.tsx
@@ -19,7 +19,7 @@ export default function PageLayout({
       <div className="container mx-auto px-4 py-8 flex-grow">
         <Link
           href={backHref}
-          className="inline-flex items-center text-[var(--accent)] hover:opacity-80 transition-opacity mb-8"
+          className="a11y-focus-ring mb-8 inline-flex items-center rounded-sm text-[var(--accent)] transition-opacity hover:opacity-80"
         >
           <ArrowLeftIcon className="h-5 w-5 mr-2" />
           {backLabel}

--- a/src/components/SubscribeForm.tsx
+++ b/src/components/SubscribeForm.tsx
@@ -5,10 +5,17 @@ import { useState } from 'react';
 export default function SubscribeForm() {
   const [email, setEmail] = useState('');
   const [status, setStatus] = useState<'idle' | 'loading' | 'success' | 'error'>('idle');
+  const [validationError, setValidationError] = useState<string | null>(null);
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
-    if (!email) return;
+    if (!email.trim()) {
+      setValidationError('Enter your email address.');
+      setStatus('idle');
+      return;
+    }
+
+    setValidationError(null);
     setStatus('loading');
     try {
       const res = await fetch('/api/subscribe', {
@@ -23,6 +30,10 @@ export default function SubscribeForm() {
     }
   }
 
+  const statusMessageId = 'subscribe-status-message';
+  const errorMessageId = 'subscribe-error-message';
+  const helperMessageId = 'subscribe-helper-message';
+
   return (
     <form onSubmit={handleSubmit} className="w-full max-w-md mx-auto space-y-3">
       <label htmlFor="subscribe-email" className="sr-only">
@@ -33,28 +44,39 @@ export default function SubscribeForm() {
         type="email"
         required
         placeholder="Your email"
+        autoComplete="email"
         value={email}
-        onChange={(e) => setEmail(e.target.value)}
-        className="w-full rounded border-2 border-[var(--surface-border)] bg-[var(--input-bg)] p-3 text-[var(--input-fg)] placeholder:text-[var(--input-placeholder)] shadow-sm transition focus:border-[var(--accent)] focus:outline-none focus:ring-2 focus:ring-[var(--focus-ring)] focus:ring-offset-2 focus:ring-offset-[var(--background)]"
+        aria-invalid={status === 'error' || Boolean(validationError)}
+        aria-describedby={`${helperMessageId}${status !== 'idle' ? ` ${statusMessageId}` : ''}${validationError || status === 'error' ? ` ${errorMessageId}` : ''}`}
+        onChange={(e) => {
+          setEmail(e.target.value);
+          if (validationError) setValidationError(null);
+          if (status !== 'idle') setStatus('idle');
+        }}
+        className="a11y-focus-ring w-full rounded border-2 border-[var(--surface-border)] bg-[var(--input-bg)] p-3 text-[var(--input-fg)] placeholder:text-[var(--input-placeholder)] shadow-sm transition focus:border-[var(--accent)]"
       />
       <button
         type="submit"
         disabled={status === 'loading'}
-        className="w-full rounded bg-[var(--accent)] px-4 py-2 font-medium text-[var(--on-accent)] shadow-sm transition focus:outline-none focus:ring-2 focus:ring-[var(--focus-ring)] focus:ring-offset-2 focus:ring-offset-[var(--background)] disabled:opacity-60"
+        className="a11y-focus-ring w-full rounded bg-[var(--accent)] px-4 py-2 font-medium text-[var(--on-accent)] shadow-sm transition disabled:opacity-60"
       >
         {status === 'loading' ? 'Subscribing…' : 'Subscribe'}
       </button>
-      <p className="text-xs text-center text-[var(--text-secondary)]">
+      <p id={helperMessageId} className="text-xs text-center text-[var(--text-secondary)]">
         No spam, unsubscribe anytime.
+      </p>
+      <p id={statusMessageId} aria-live="polite" className="sr-only">
+        {status === 'loading' ? 'Submitting your subscription request.' : ''}
+        {status === 'success' ? 'Subscription successful. Check your inbox for confirmation.' : ''}
       </p>
       {status === 'success' && (
         <p className="text-center font-medium text-[var(--status-success)]">
           Check your inbox for confirmation! 🎉
         </p>
       )}
-      {status === 'error' && (
-        <p className="text-center font-medium text-[var(--status-error)]">
-          Something went wrong. Try again.
+      {(validationError || status === 'error') && (
+        <p id={errorMessageId} role="alert" className="text-center font-medium text-[var(--status-error)]">
+          {validationError ?? 'Something went wrong. Try again.'}
         </p>
       )}
     </form>

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -17,7 +17,7 @@ export default function Header({ className, navItems }: HeaderProps) {
     <header className={cn('py-4 transparent', className)}>
       <a
         href="#main-content"
-        className="sr-only focus:not-sr-only focus:absolute focus:z-50 focus:top-4 focus:left-4 focus:rounded focus:bg-[var(--accent)] focus:px-4 focus:py-2 focus:text-sm focus:font-medium focus:text-[var(--on-accent)]"
+        className="sr-only focus-visible:not-sr-only focus-visible:absolute focus-visible:z-50 focus-visible:top-4 focus-visible:left-4 focus-visible:rounded focus-visible:bg-[var(--accent)] focus-visible:px-4 focus-visible:py-2 focus-visible:text-sm focus-visible:font-medium focus-visible:text-[var(--on-accent)]"
       >
         Skip to content
       </a>
@@ -29,7 +29,7 @@ export default function Header({ className, navItems }: HeaderProps) {
           <nav aria-label="Main navigation" className="flex justify-center">
             <Link
               href="/"
-              className="text-center text-xl font-bold text-[var(--accent)] hover:opacity-80 transition-opacity"
+              className="a11y-focus-ring rounded-sm text-center text-xl font-bold text-[var(--accent)] transition-opacity hover:opacity-80"
             >
               {SITE_NAME}
             </Link>

--- a/src/components/layout/SiteNav.tsx
+++ b/src/components/layout/SiteNav.tsx
@@ -7,7 +7,7 @@ import { type SiteNavItem, isNavActive } from '@/config/site-nav';
 import { cn } from '@/utils/helpers';
 
 const linkClass =
-  'text-[var(--text-secondary)] hover:text-[var(--accent)] transition-colors focus:outline-none focus:ring-2 focus:ring-[var(--focus-ring)] focus:ring-offset-2 focus:ring-offset-[var(--background)] rounded-sm';
+  'a11y-focus-ring rounded-sm text-[var(--text-secondary)] transition-colors hover:text-[var(--accent)]';
 
 const activeClass = 'text-[var(--accent)] font-medium';
 


### PR DESCRIPTION
## Summary
- Added a reusable `a11y-focus-ring` utility and applied it to key links, cards, and navigation elements.
- Improved blog post link visibility by adding clearer underline styling and focus states for in-content links.
- Updated the subscribe form with inline validation, `aria-*` messaging, live status updates, and clearer error handling.
- Made the skip link activate on `focus-visible` and adjusted heading/card semantics for better structure.

## Testing
- Not run (changes reviewed from diff only).
- Confirm keyboard focus rings appear on primary navigation, cards, and link buttons.
- Confirm the subscribe form shows a validation error for empty submissions and announces loading/success/error states.
- Confirm blog content links remain readable and visibly focused in post pages.