### PR TITLE
Standardize SEO metadata and canonical URL sources

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,4 +1,0 @@
-User-agent: *
-Allow: /
-
-Sitemap: https://saucy.tech/sitemap.xml

--- a/src/app/.well-known/lnurlp/brandon/route.ts
+++ b/src/app/.well-known/lnurlp/brandon/route.ts
@@ -4,10 +4,9 @@ import { LNURL_CONFIG } from '@/utils/lnurl-config';
 
 export async function GET() {
   const username = 'brandon';
-  const appUrl = process.env.NEXT_PUBLIC_APP_URL || SITE_URL;
 
   const responseData = {
-    callback: `${appUrl}/api/lnurlp/${username}/callback`,
+    callback: `${SITE_URL}/api/lnurlp/${username}/callback`,
     maxSendable: LNURL_CONFIG.maxSendable,
     minSendable: LNURL_CONFIG.minSendable,
     metadata: LNURL_CONFIG.metadata,

--- a/src/app/bitcoin/page.tsx
+++ b/src/app/bitcoin/page.tsx
@@ -3,15 +3,18 @@ import Image from 'next/image';
 import Link from 'next/link';
 
 import PageLayout from '@/components/PageLayout';
-import { SITE_NAME, SITE_URL } from '@/utils/constants';
+import { SITE_NAME } from '@/utils/constants';
 
 export const metadata: Metadata = {
   title: 'Bitcoin Resources',
   description: 'Explore the ideas and resources that shaped my understanding of Bitcoin.',
+  alternates: {
+    canonical: '/bitcoin',
+  },
   openGraph: {
     title: 'Learn About Bitcoin',
     description: 'Explore the ideas and resources that shaped my understanding of Bitcoin.',
-    url: `${SITE_URL}/bitcoin`,
+    url: '/bitcoin',
     type: 'website',
     images: [
       {

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -15,7 +15,7 @@ import {
   getPostOgMeta,
   seriesSlug,
 } from '@/utils/posts';
-import { SITE_NAME, SITE_URL } from '@/utils/constants';
+import { SITE_NAME, SITE_URL, absoluteUrl } from '@/utils/constants';
 
 function getReadingTime(content: string) {
   const plainText = content
@@ -69,7 +69,9 @@ export default async function PostPage({ params }: PostPageProps) {
     headline: post.title,
     description: post.excerpt,
     datePublished: post.date,
-    url: `${SITE_URL}/blog/${post.slug}`,
+    dateModified: post.date,
+    url: absoluteUrl(`/blog/${post.slug}`),
+    mainEntityOfPage: absoluteUrl(`/blog/${post.slug}`),
     image: getPostOgImageUrl(post.slug),
     author: {
       '@type': 'Person',
@@ -80,6 +82,10 @@ export default async function PostPage({ params }: PostPageProps) {
       '@type': 'Organization',
       name: SITE_NAME,
       url: SITE_URL,
+      logo: {
+        '@type': 'ImageObject',
+        url: absoluteUrl('/favicon.ico'),
+      },
     },
     articleSection: post.category,
     keywords: post.tags,
@@ -141,7 +147,7 @@ export default async function PostPage({ params }: PostPageProps) {
 
         <ShareButtons
           title={post.title}
-          url={`${SITE_URL}/blog/${post.slug}`}
+          url={absoluteUrl(`/blog/${post.slug}`)}
           excerpt={post.excerpt}
         />
 

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -1,4 +1,5 @@
 import Link from 'next/link';
+import type { Metadata } from 'next';
 
 import BlogArchive from '@/components/BlogArchive';
 import PageLayout from '@/components/PageLayout';
@@ -8,9 +9,15 @@ import { formatPostDate } from '@/utils/helpers';
 import { getAllPostsMeta } from '@/utils/posts';
 import { POST_CATEGORIES } from '@/utils/post-taxonomy';
 
-export const metadata = {
+export const metadata: Metadata = {
   title: 'Articles & Reflections',
   description: 'Daily Word posts, biblical reflections, and essays.',
+  alternates: {
+    canonical: '/blog',
+  },
+  openGraph: {
+    url: '/blog',
+  },
 };
 
 export default function BlogIndex() {

--- a/src/app/blog/series/[series]/page.tsx
+++ b/src/app/blog/series/[series]/page.tsx
@@ -65,6 +65,12 @@ export async function generateMetadata({ params }: SeriesPageProps): Promise<Met
   return {
     title: `${series.name} — Series`,
     description: `All ${series.count} posts in the "${series.name}" series.`,
+    alternates: {
+      canonical: `/blog/series/${series.slug}`,
+    },
+    openGraph: {
+      url: `/blog/series/${series.slug}`,
+    },
   };
 }
 

--- a/src/app/blog/series/page.tsx
+++ b/src/app/blog/series/page.tsx
@@ -8,6 +8,12 @@ import { getAllSeries } from '@/utils/posts';
 export const metadata: Metadata = {
   title: 'Blog Series',
   description: "Browse all multi-part series from Brandon's blog, organized by topic.",
+  alternates: {
+    canonical: '/blog/series',
+  },
+  openGraph: {
+    url: '/blog/series',
+  },
 };
 
 export default function SeriesIndexPage() {

--- a/src/app/daily-word/page.tsx
+++ b/src/app/daily-word/page.tsx
@@ -5,17 +5,19 @@ import PageLayout from '@/components/PageLayout';
 import SubscribeForm from '@/components/SubscribeForm';
 import { formatPostDate } from '@/utils/helpers';
 import { getAllPostsMeta } from '@/utils/posts';
-import { SITE_URL } from '@/utils/constants';
 
 export const metadata: Metadata = {
   title: 'The Daily Word',
   description:
     "Free weekday scripture reflections and notes from Brandon's Sunday School series. Subscribe to get each post by email.",
+  alternates: {
+    canonical: '/daily-word',
+  },
   openGraph: {
     title: 'The Daily Word',
     description:
       "Free weekday scripture reflections and notes from Brandon's Sunday School series. Subscribe to get each post by email.",
-    url: `${SITE_URL}/daily-word`,
+    url: '/daily-word',
   },
 };
 

--- a/src/app/field-notes/page.tsx
+++ b/src/app/field-notes/page.tsx
@@ -5,17 +5,20 @@ import PageLayout from '@/components/PageLayout';
 import Section from '@/components/Section';
 import { fieldNotesLastUpdated, fieldNotesSections } from '@/data/field-notes';
 import { formatPostDate } from '@/utils/helpers';
-import { SITE_NAME, SITE_URL } from '@/utils/constants';
+import { SITE_NAME } from '@/utils/constants';
 
 export const metadata: Metadata = {
   title: `Field notes | ${SITE_NAME}`,
   description:
     'What I\u2019m into in tech right now — tools I\u2019m using and things I\u2019m trying. Updated when it changes.',
+  alternates: {
+    canonical: '/field-notes',
+  },
   openGraph: {
     title: `Field notes | ${SITE_NAME}`,
     description:
       'What I\u2019m into in tech right now — tools I\u2019m using and things I\u2019m trying.',
-    url: `${SITE_URL}/field-notes`,
+    url: '/field-notes',
     type: 'website',
   },
 };

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -34,6 +34,9 @@ export const viewport: Viewport = {
 
 export const metadata: Metadata = {
   metadataBase: new URL(SITE_URL),
+  alternates: {
+    canonical: '/',
+  },
   title: {
     default: SITE_NAME,
     template: `%s | ${SITE_NAME}`,
@@ -56,7 +59,7 @@ export const metadata: Metadata = {
   openGraph: {
     type: 'website',
     locale: 'en_US',
-    url: SITE_URL,
+    url: '/',
     siteName: SITE_NAME,
     title: SITE_NAME,
     description: SITE_DESCRIPTION,
@@ -73,7 +76,7 @@ export const metadata: Metadata = {
     card: 'summary_large_image',
     title: SITE_NAME,
     description: SITE_DESCRIPTION,
-    images: [`${SITE_URL}/family-photo.jpeg`],
+    images: ['/family-photo.jpeg'],
     creator: '@Saucy_Tech',
   },
   icons: {
@@ -99,7 +102,6 @@ export default async function RootLayout({ children }: { children: React.ReactNo
             __html: `(function(){try{var t=${JSON.stringify(THEME_STORAGE_KEY)};var a=${JSON.stringify(APPEARANCE_STORAGE_KEY)};if(localStorage.getItem(t)==='green')document.documentElement.setAttribute('data-theme','green');if(localStorage.getItem(a)==='light')document.documentElement.setAttribute('data-appearance','light');}catch(e){}})();`,
           }}
         />
-        <link rel="apple-touch-icon" sizes="180x180" href={`${SITE_URL}/apple-touch-icon.png`} />
       </head>
       <body className={`${ibmSans.variable} ${ibmMono.variable} font-sans antialiased`}>
         {/* Background canvas and content wrapper */}

--- a/src/app/links/page.tsx
+++ b/src/app/links/page.tsx
@@ -3,16 +3,19 @@ import { Activity, BarChart2, Building2, Calculator, Database, TrendingUp } from
 
 import LinkCard from '@/components/LinkCard';
 import PageLayout from '@/components/PageLayout';
-import { SITE_NAME, SITE_URL } from '@/utils/constants';
+import { SITE_NAME } from '@/utils/constants';
 
 export const metadata: Metadata = {
   title: `Bitcoin Links | ${SITE_NAME}`,
   description: 'Favorite Bitcoin trackers, calculators, and dashboards.',
   robots: { index: false, follow: false },
+  alternates: {
+    canonical: '/links',
+  },
   openGraph: {
     title: 'Bitcoin Links',
     description: 'Favorite Bitcoin trackers, calculators, and dashboards.',
-    url: `${SITE_URL}/links`,
+    url: '/links',
     type: 'website',
   },
 };

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,7 @@
 import Image from 'next/image';
 import Link from 'next/link';
 import { headers } from 'next/headers';
+import type { Metadata } from 'next';
 
 import LinkCard from '@/components/LinkCard';
 import Profile from '@/components/Profile';
@@ -9,7 +10,16 @@ import SocialBar from '@/components/SocialBar';
 import SubscribeForm from '@/components/SubscribeForm';
 import { formatPostDate } from '@/utils/helpers';
 import { getAllPostsMeta } from '@/utils/posts';
-import { SITE_NAME, SITE_URL, SITE_DESCRIPTION } from '@/utils/constants';
+import { SITE_NAME, SITE_URL, SITE_DESCRIPTION, absoluteUrl } from '@/utils/constants';
+
+export const metadata: Metadata = {
+  alternates: {
+    canonical: '/',
+  },
+  openGraph: {
+    url: '/',
+  },
+};
 
 /** Inline JSON-LD uses CSP nonce from middleware; avoid static prerender without that header. */
 export const dynamic = 'force-dynamic';
@@ -82,10 +92,25 @@ export default async function Home() {
 
   const jsonLd = {
     '@context': 'https://schema.org',
-    '@type': 'WebSite',
-    name: SITE_NAME,
-    url: SITE_URL,
-    description: SITE_DESCRIPTION,
+    '@graph': [
+      {
+        '@type': 'Person',
+        name: 'Brandon',
+        url: SITE_URL,
+        image: absoluteUrl('/family-photo.jpeg'),
+        sameAs: [
+          'https://x.com/Saucy_Tech',
+          'https://github.com/saucy-tech',
+          'https://primal.net/p/nprofile1qqsvzs8gfntzjs2wg8670nrfy64h44zy69kc3r8rp5wd7kw6t6njsassf62c7',
+        ],
+      },
+      {
+        '@type': 'WebSite',
+        name: SITE_NAME,
+        url: SITE_URL,
+        description: SITE_DESCRIPTION,
+      },
+    ],
   };
 
   return (

--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -1,14 +1,17 @@
 import PageLayout from '@/components/PageLayout';
 import { Metadata } from 'next';
-import { SITE_NAME, SITE_URL } from '@/utils/constants';
+import { SITE_NAME } from '@/utils/constants';
 
 export const metadata: Metadata = {
   title: 'Projects & Contributions',
   description: `Explore Brandon's projects and open-source contributions.`,
+  alternates: {
+    canonical: '/projects',
+  },
   openGraph: {
     title: 'Projects',
     description: `Explore Brandon's projects, apps, and experiments.`,
-    url: `${SITE_URL}/projects`,
+    url: '/projects',
     type: 'website',
     images: [
       {

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,0 +1,13 @@
+import type { MetadataRoute } from 'next';
+
+import { absoluteUrl } from '@/utils/constants';
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: '*',
+      allow: '/',
+    },
+    sitemap: absoluteUrl('/sitemap.xml'),
+  };
+}

--- a/src/app/rss.xml/route.ts
+++ b/src/app/rss.xml/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 
-import { SITE_URL } from '@/utils/constants';
+import { absoluteUrl } from '@/utils/constants';
 import { getAllPostsMeta } from '@/utils/posts';
 
 export const dynamic = 'force-static';
@@ -12,7 +12,7 @@ export async function GET() {
     .map((post) => {
       return `<item>
         <title>${post.title}</title>
-        <link>${SITE_URL}/blog/${post.slug}</link>
+        <link>${absoluteUrl(`/blog/${post.slug}`)}</link>
         <pubDate>${new Date(post.date).toUTCString()}</pubDate>
         <description><![CDATA[${post.excerpt ?? ''}]]></description>
       </item>`;
@@ -23,7 +23,7 @@ export async function GET() {
   <rss version="2.0">
     <channel>
       <title>Brandon's Blog</title>
-      <link>${SITE_URL}</link>
+      <link>${absoluteUrl('/')}</link>
       <description>Thoughts and writings</description>
       ${items}
     </channel>

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,18 +1,18 @@
 import { MetadataRoute } from 'next';
 
-import { SITE_URL } from '@/utils/constants';
+import { absoluteUrl } from '@/utils/constants';
 import { getAllPostsMeta, getAllSeries } from '@/utils/posts';
 
 export default function sitemap(): MetadataRoute.Sitemap {
   const posts = getAllPostsMeta().map((post) => ({
-    url: `${SITE_URL}/blog/${post.slug}`,
+    url: absoluteUrl(`/blog/${post.slug}`),
     lastModified: post.date,
     changeFrequency: 'monthly' as const,
     priority: 0.7,
   }));
 
   const seriesPages = getAllSeries().map((series) => ({
-    url: `${SITE_URL}/blog/series/${series.slug}`,
+    url: absoluteUrl(`/blog/series/${series.slug}`),
     lastModified: series.posts[series.posts.length - 1]?.date ?? new Date().toISOString(),
     changeFrequency: 'weekly' as const,
     priority: 0.6,
@@ -20,43 +20,43 @@ export default function sitemap(): MetadataRoute.Sitemap {
 
   return [
     {
-      url: SITE_URL,
+      url: absoluteUrl('/'),
       lastModified: new Date(),
       changeFrequency: 'weekly',
       priority: 1,
     },
     {
-      url: `${SITE_URL}/support`,
+      url: absoluteUrl('/support'),
       lastModified: new Date(),
       changeFrequency: 'monthly',
       priority: 0.8,
     },
     {
-      url: `${SITE_URL}/blog`,
+      url: absoluteUrl('/blog'),
       lastModified: new Date(),
       changeFrequency: 'monthly',
       priority: 0.8,
     },
     {
-      url: `${SITE_URL}/daily-word`,
+      url: absoluteUrl('/daily-word'),
       lastModified: new Date(),
       changeFrequency: 'weekly',
       priority: 0.9,
     },
     {
-      url: `${SITE_URL}/field-notes`,
+      url: absoluteUrl('/field-notes'),
       lastModified: new Date(),
       changeFrequency: 'weekly',
       priority: 0.65,
     },
     {
-      url: `${SITE_URL}/rss.xml`,
+      url: absoluteUrl('/rss.xml'),
       lastModified: new Date(),
       changeFrequency: 'monthly',
       priority: 0.5,
     },
     {
-      url: `${SITE_URL}/blog/series`,
+      url: absoluteUrl('/blog/series'),
       lastModified: new Date(),
       changeFrequency: 'weekly',
       priority: 0.6,

--- a/src/app/support/page.tsx
+++ b/src/app/support/page.tsx
@@ -1,16 +1,19 @@
 import PageLayout from '@/components/PageLayout';
 import { Metadata } from 'next';
-import { SITE_NAME, SITE_URL } from '@/utils/constants';
+import { SITE_NAME } from '@/utils/constants';
 import ClientTipJar from '@/components/ClientTipJar';
 import Section from '@/components/Section';
 
 export const metadata: Metadata = {
   title: 'Support Me',
   description: "Support Brandon's writing, projects, and long-term vision for his family.",
+  alternates: {
+    canonical: '/support',
+  },
   openGraph: {
     title: 'Support Me',
     description: "Contribute to Brandon's work, family savings, or send Bitcoin.",
-    url: `${SITE_URL}/support`,
+    url: '/support',
     type: 'website',
     images: [
       {

--- a/src/app/talks/page.tsx
+++ b/src/app/talks/page.tsx
@@ -1,14 +1,17 @@
 import PageLayout from '@/components/PageLayout';
 import { Metadata } from 'next';
-import { SITE_NAME, SITE_URL } from '@/utils/constants';
+import { SITE_NAME } from '@/utils/constants';
 
 export const metadata: Metadata = {
   title: 'Talks & Sermons',
   description: `Archive of faith-based messages and technical talks by Brandon.`,
+  alternates: {
+    canonical: '/talks',
+  },
   openGraph: {
     title: 'Talks & Sermons',
     description: `Archive of faith-based messages and technical talks by Brandon.`,
-    url: `${SITE_URL}/talks`,
+    url: '/talks',
     type: 'website',
     images: [
       {

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,3 +1,20 @@
 export const SITE_NAME = 'Saucy.Tech';
 export const SITE_DESCRIPTION = 'Love Jesus, Explore Ideas, Create Things, Save in Bitcoin';
-export const SITE_URL = process.env.NEXT_PUBLIC_APP_URL || 'https://saucy.tech';
+
+function normalizeSiteUrl(value: string): string {
+  return value.trim().replace(/\/+$/, '');
+}
+
+export function getSiteUrl(): string {
+  const configuredUrl = process.env.SITE_URL || process.env.NEXT_PUBLIC_APP_URL;
+  if (!configuredUrl) {
+    return 'https://saucy.tech';
+  }
+  return normalizeSiteUrl(configuredUrl);
+}
+
+export const SITE_URL = getSiteUrl();
+
+export function absoluteUrl(pathname = '/'): string {
+  return new URL(pathname, `${SITE_URL}/`).toString();
+}

--- a/src/utils/posts.ts
+++ b/src/utils/posts.ts
@@ -7,7 +7,7 @@ import yaml from 'js-yaml';
 
 import { Post, PostMeta, toPostMeta } from '@/utils/post-taxonomy';
 import { frontmatterSchema } from '@/utils/frontmatter-schema';
-import { SITE_URL } from '@/utils/constants';
+import { absoluteUrl } from '@/utils/constants';
 
 export interface SeriesMeta {
   name: string;
@@ -204,7 +204,7 @@ export async function getPostBySlug(
 }
 
 export function getPostOgImageUrl(slug: string): string {
-  return `${SITE_URL}/blog/${slug}/opengraph-image`;
+  return absoluteUrl(`/blog/${slug}/opengraph-image`);
 }
 
 export async function getPostOgMeta(slug: string): Promise<Metadata | null> {
@@ -215,16 +215,20 @@ export async function getPostOgMeta(slug: string): Promise<Metadata | null> {
 
   const { title, excerpt } = post;
   const imageUrl = getPostOgImageUrl(slug);
-  const url = `${SITE_URL}/blog/${slug}`;
+  const url = absoluteUrl(`/blog/${slug}`);
 
   return {
     title,
     description: excerpt,
+    alternates: {
+      canonical: `/blog/${slug}`,
+    },
     openGraph: {
       title,
       description: excerpt,
       type: 'article',
       url,
+      publishedTime: post.date,
       images: [
         {
           url: imageUrl,


### PR DESCRIPTION
## Summary
- consolidate public URL generation behind a single site base helper (`getSiteUrl`/`absoluteUrl`) and use it for canonical, Open Graph, Twitter, sitemap, RSS, and LNURL callback URLs
- align App Router metadata exports across pages by setting explicit canonical alternates and consistent `openGraph.url` values anchored to `metadataBase`
- add structured data for SEO consistency: homepage `Person` + `WebSite` JSON-LD and post-level `BlogPosting` JSON-LD with canonical URLs, dates, and image references
- replace static `public/robots.txt` with generated `src/app/robots.ts` so robots and sitemap stay in sync with the same base URL

## Test plan
- [x] `pnpm lint`
- [x] `curl` homepage/blog/post/daily-word and verify exactly one canonical tag and a matching `og:url`
- [x] `curl /robots.txt` and `curl /sitemap.xml` to confirm consistent base URLs

Made with [Cursor](https://cursor.com)