### PR TITLE
Add post table of contents and related-post scoring

### DIFF
--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -31,7 +31,7 @@ function getHeadingText(node: ReactNode): string {
     return node.map((child) => getHeadingText(child)).join(' ');
   }
 
-  if (isValidElement(node)) {
+  if (isValidElement<{ children?: ReactNode }>(node)) {
     return getHeadingText(node.props.children);
   }
 

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -2,8 +2,11 @@ import Link from 'next/link';
 import { MDXRemote } from 'next-mdx-remote/rsc';
 import { headers } from 'next/headers';
 import { notFound } from 'next/navigation';
+import { isValidElement } from 'react';
+import type { ComponentPropsWithoutRef, ReactNode } from 'react';
 
 import PageLayout from '@/components/PageLayout';
+import PostTableOfContents from '@/components/PostTableOfContents';
 import Section from '@/components/Section';
 import ShareButtons from '@/components/ShareButtons';
 import SubscribeForm from '@/components/SubscribeForm';
@@ -13,21 +16,26 @@ import {
   getPostBySlug,
   getPostOgImageUrl,
   getPostOgMeta,
+  getRelatedPosts,
   seriesSlug,
+  slugifyHeading,
 } from '@/utils/posts';
 import { SITE_NAME, SITE_URL, absoluteUrl } from '@/utils/constants';
 
-function getReadingTime(content: string) {
-  const plainText = content
-    .replace(/^---[\s\S]*?---/, '')
-    .replace(/!\[[^\]]*]\([^)]*\)/g, ' ')
-    .replace(/\[([^\]]+)]\([^)]*\)/g, '$1')
-    .replace(/[`*_>#-]/g, ' ')
-    .replace(/\s+/g, ' ')
-    .trim();
-  const wordCount = plainText ? plainText.split(' ').length : 0;
+function getHeadingText(node: ReactNode): string {
+  if (typeof node === 'string' || typeof node === 'number') {
+    return String(node);
+  }
 
-  return Math.max(1, Math.ceil(wordCount / 200));
+  if (Array.isArray(node)) {
+    return node.map((child) => getHeadingText(child)).join(' ');
+  }
+
+  if (isValidElement(node)) {
+    return getHeadingText(node.props.children);
+  }
+
+  return '';
 }
 
 export async function generateStaticParams() {
@@ -57,11 +65,26 @@ export default async function PostPage({ params }: PostPageProps) {
   if (!post) {
     notFound();
   }
-  const readingTime = getReadingTime(post.content);
-  const relatedPosts = getAllPostsMeta()
-    .filter((candidate) => candidate.slug !== post.slug)
-    .filter((candidate) => candidate.category === post.category)
-    .slice(0, 3);
+  const relatedPosts = getRelatedPosts(post, 3);
+  const showTableOfContents = post.headings.length >= 3;
+  const mdxComponents = {
+    h2: ({ children, ...props }: ComponentPropsWithoutRef<'h2'>) => {
+      const id = slugifyHeading(getHeadingText(children));
+      return (
+        <h2 {...props} id={id}>
+          {children}
+        </h2>
+      );
+    },
+    h3: ({ children, ...props }: ComponentPropsWithoutRef<'h3'>) => {
+      const id = slugifyHeading(getHeadingText(children));
+      return (
+        <h3 {...props} id={id}>
+          {children}
+        </h3>
+      );
+    },
+  };
 
   const jsonLd = {
     '@context': 'https://schema.org',
@@ -99,105 +122,119 @@ export default async function PostPage({ params }: PostPageProps) {
         {...(nonce ? { nonce } : {})}
         dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
       />
-      <div className="mx-auto max-w-3xl space-y-10">
-        <section className="overflow-hidden rounded-[2rem] border border-[var(--accent-border)] bg-[radial-gradient(circle_at_top_right,rgb(var(--accent-rgb)/0.18),transparent_42%),linear-gradient(180deg,rgba(255,255,255,0.05),rgba(255,255,255,0.02))] p-6 sm:p-8">
-          <div className="flex flex-wrap gap-2">
-            <span className="rounded-full border border-[var(--accent-border)] bg-[var(--accent-transparent)] px-3 py-1 text-xs uppercase tracking-[0.18em] text-[var(--accent)]">
-              {post.categoryLabel}
-            </span>
-            <span className="rounded-full border border-white/10 bg-black/10 px-3 py-1 text-xs text-[var(--text-secondary)]">
-              {formatPostDate(post.date)}
-            </span>
-            <span className="rounded-full border border-white/10 bg-black/10 px-3 py-1 text-xs text-[var(--text-secondary)]">
-              {readingTime} min read
-            </span>
-            {post.series && (
-              <Link
-                href={`/blog/series/${seriesSlug(post.series)}`}
-                className="a11y-focus-ring rounded-full border border-white/10 bg-black/10 px-3 py-1 text-xs text-[var(--text-secondary)] transition hover:border-[var(--accent-border)] hover:text-[var(--accent)]"
-              >
-                {post.series}
-              </Link>
-            )}
-          </div>
-
-          {post.excerpt && (
-            <p className="mt-6 max-w-2xl text-lg leading-relaxed text-[var(--text-secondary)] sm:text-xl">
-              {post.excerpt}
-            </p>
-          )}
-
-          {post.tags.length > 0 && (
-            <div className="mt-6 flex flex-wrap gap-2">
-              {post.tags.map((tag) => (
-                <span
-                  key={tag}
-                  className="rounded-full border border-white/10 bg-black/10 px-3 py-1 text-xs text-[var(--text-secondary)]"
-                >
-                  {tag}
-                </span>
-              ))}
-            </div>
-          )}
-        </section>
-
-        <article className="prose prose-invert prose-p:text-[1.05rem] prose-p:leading-8 prose-headings:scroll-mt-24 prose-headings:font-semibold prose-headings:text-[var(--text-primary)] prose-h2:mt-12 prose-h2:border-t prose-h2:border-white/10 prose-h2:pt-8 prose-h2:text-2xl prose-h3:mt-10 prose-h3:text-xl prose-a:text-[var(--accent)] prose-a:no-underline prose-a:decoration-[0.1em] prose-a:underline-offset-[0.2em] hover:prose-a:text-[var(--text-primary)] prose-a:focus-visible:rounded-sm prose-a:focus-visible:outline-none prose-a:focus-visible:ring-2 prose-a:focus-visible:ring-[var(--focus-ring)] prose-a:focus-visible:ring-offset-2 prose-a:focus-visible:ring-offset-[var(--background)] prose-strong:text-[var(--text-primary)] prose-blockquote:rounded-2xl prose-blockquote:border-l-4 prose-blockquote:border-[var(--accent)] prose-blockquote:bg-white/[0.04] prose-blockquote:px-6 prose-blockquote:py-4 prose-blockquote:text-[var(--text-primary)] prose-hr:border-white/10 prose-img:rounded-3xl prose-img:border prose-img:border-white/10 prose-img:shadow-[0_18px_40px_rgba(0,0,0,0.25)] prose-figcaption:text-sm prose-figcaption:text-[var(--text-secondary)] max-w-none">
-          <MDXRemote source={post.content} />
-        </article>
-
-        <ShareButtons
-          title={post.title}
-          url={absoluteUrl(`/blog/${post.slug}`)}
-          excerpt={post.excerpt}
-        />
-
-        {relatedPosts.length > 0 && (
-          <section className="rounded-[2rem] border border-white/10 bg-white/[0.03] p-6 sm:p-8">
-            <div className="flex items-center justify-between gap-4">
-              <div>
-                <p className="text-sm uppercase tracking-[0.18em] text-[var(--accent)]">
-                  Recent Posts
-                </p>
-                <h2 className="mt-2 text-2xl font-semibold text-[var(--text-primary)]">
-                  Latest in {post.categoryLabel}
-                </h2>
-              </div>
-              <Link
-                href="/blog"
-                className="a11y-focus-ring rounded-sm text-sm font-medium text-[var(--accent)] transition hover:text-[var(--text-primary)]"
-              >
-                Browse all posts
-              </Link>
-            </div>
-
-            <div className="mt-6 grid gap-4 md:grid-cols-3">
-              {relatedPosts.map((relatedPost) => (
+      <div className="mx-auto grid max-w-6xl gap-8 xl:grid-cols-[minmax(0,1fr)_18rem]">
+        <div id="post-top" className="space-y-10">
+          <section className="overflow-hidden rounded-[2rem] border border-[var(--accent-border)] bg-[radial-gradient(circle_at_top_right,rgb(var(--accent-rgb)/0.18),transparent_42%),linear-gradient(180deg,rgba(255,255,255,0.05),rgba(255,255,255,0.02))] p-6 sm:p-8">
+            <div className="flex flex-wrap gap-2">
+              <span className="rounded-full border border-[var(--accent-border)] bg-[var(--accent-transparent)] px-3 py-1 text-xs uppercase tracking-[0.18em] text-[var(--accent)]">
+                {post.categoryLabel}
+              </span>
+              <span className="rounded-full border border-white/10 bg-black/10 px-3 py-1 text-xs text-[var(--text-secondary)]">
+                {formatPostDate(post.date)}
+              </span>
+              <span className="rounded-full border border-white/10 bg-black/10 px-3 py-1 text-xs text-[var(--text-secondary)]">
+                {post.readingTimeMinutes} min read
+              </span>
+              {post.series && (
                 <Link
-                  key={relatedPost.slug}
-                  href={`/blog/${relatedPost.slug}`}
-                  className="a11y-focus-ring group rounded-3xl border border-[var(--accent-border)] bg-black/10 p-5 transition hover:border-[var(--accent)] hover:bg-[var(--accent-transparent)]"
+                  href={`/blog/series/${seriesSlug(post.series)}`}
+                  className="a11y-focus-ring rounded-full border border-white/10 bg-black/10 px-3 py-1 text-xs text-[var(--text-secondary)] transition hover:border-[var(--accent-border)] hover:text-[var(--accent)]"
                 >
-                  <p className="text-xs uppercase tracking-[0.18em] text-[var(--accent)]">
-                    {formatPostDate(relatedPost.date)}
-                  </p>
-                  <h3 className="mt-3 text-xl font-semibold leading-tight text-[var(--text-primary)] transition group-hover:text-[var(--accent)]">
-                    {relatedPost.title}
-                  </h3>
-                  <p className="mt-3 text-sm leading-relaxed text-[var(--text-secondary)]">
-                    {relatedPost.excerpt}
-                  </p>
+                  {post.series}
                 </Link>
-              ))}
+              )}
             </div>
-          </section>
-        )}
 
-        <Section title="Subscribe to The Daily Word" emoji="✉️">
-          <p className="text-sm leading-relaxed text-[var(--text-secondary)]">
-            Enjoyed this? Get The Daily Word in your inbox every weekday morning. Free, always.
-          </p>
-          <SubscribeForm />
-        </Section>
+            {post.excerpt && (
+              <p className="mt-6 max-w-2xl text-lg leading-relaxed text-[var(--text-secondary)] sm:text-xl">
+                {post.excerpt}
+              </p>
+            )}
+
+            {post.tags.length > 0 && (
+              <div className="mt-6 flex flex-wrap gap-2">
+                {post.tags.map((tag) => (
+                  <span
+                    key={tag}
+                    className="rounded-full border border-white/10 bg-black/10 px-3 py-1 text-xs text-[var(--text-secondary)]"
+                  >
+                    {tag}
+                  </span>
+                ))}
+              </div>
+            )}
+          </section>
+
+          {showTableOfContents && (
+            <div className="xl:hidden">
+              <PostTableOfContents headings={post.headings} />
+            </div>
+          )}
+
+          <article className="prose prose-invert prose-p:text-[1.05rem] prose-p:leading-8 prose-headings:scroll-mt-24 prose-headings:font-semibold prose-headings:text-[var(--text-primary)] prose-h2:mt-12 prose-h2:border-t prose-h2:border-white/10 prose-h2:pt-8 prose-h2:text-2xl prose-h3:mt-10 prose-h3:text-xl prose-a:text-[var(--accent)] prose-a:no-underline prose-a:decoration-[0.1em] prose-a:underline-offset-[0.2em] hover:prose-a:text-[var(--text-primary)] prose-a:focus-visible:rounded-sm prose-a:focus-visible:outline-none prose-a:focus-visible:ring-2 prose-a:focus-visible:ring-[var(--focus-ring)] prose-a:focus-visible:ring-offset-2 prose-a:focus-visible:ring-offset-[var(--background)] prose-strong:text-[var(--text-primary)] prose-blockquote:rounded-2xl prose-blockquote:border-l-4 prose-blockquote:border-[var(--accent)] prose-blockquote:bg-white/[0.04] prose-blockquote:px-6 prose-blockquote:py-4 prose-blockquote:text-[var(--text-primary)] prose-hr:border-white/10 prose-img:rounded-3xl prose-img:border prose-img:border-white/10 prose-img:shadow-[0_18px_40px_rgba(0,0,0,0.25)] prose-figcaption:text-sm prose-figcaption:text-[var(--text-secondary)] max-w-none">
+            <MDXRemote source={post.content} components={mdxComponents} />
+          </article>
+
+          <ShareButtons
+            title={post.title}
+            url={absoluteUrl(`/blog/${post.slug}`)}
+            excerpt={post.excerpt}
+          />
+
+          {relatedPosts.length > 0 && (
+            <section className="rounded-[2rem] border border-white/10 bg-white/[0.03] p-6 sm:p-8">
+              <div className="flex items-center justify-between gap-4">
+                <div>
+                  <p className="text-sm uppercase tracking-[0.18em] text-[var(--accent)]">
+                    Related Posts
+                  </p>
+                  <h2 className="mt-2 text-2xl font-semibold text-[var(--text-primary)]">
+                    Keep reading
+                  </h2>
+                </div>
+                <Link
+                  href="/blog"
+                  className="a11y-focus-ring rounded-sm text-sm font-medium text-[var(--accent)] transition hover:text-[var(--text-primary)]"
+                >
+                  Browse all posts
+                </Link>
+              </div>
+
+              <div className="mt-6 grid gap-4 md:grid-cols-3">
+                {relatedPosts.map((relatedPost) => (
+                  <Link
+                    key={relatedPost.slug}
+                    href={`/blog/${relatedPost.slug}`}
+                    className="a11y-focus-ring group rounded-3xl border border-[var(--accent-border)] bg-black/10 p-5 transition hover:border-[var(--accent)] hover:bg-[var(--accent-transparent)]"
+                  >
+                    <p className="text-xs uppercase tracking-[0.18em] text-[var(--accent)]">
+                      {formatPostDate(relatedPost.date)}
+                    </p>
+                    <h3 className="mt-3 text-xl font-semibold leading-tight text-[var(--text-primary)] transition group-hover:text-[var(--accent)]">
+                      {relatedPost.title}
+                    </h3>
+                    <p className="mt-3 text-sm leading-relaxed text-[var(--text-secondary)]">
+                      {relatedPost.excerpt}
+                    </p>
+                  </Link>
+                ))}
+              </div>
+            </section>
+          )}
+
+          <Section title="Subscribe to The Daily Word" emoji="✉️">
+            <p className="text-sm leading-relaxed text-[var(--text-secondary)]">
+              Enjoyed this? Get The Daily Word in your inbox every weekday morning. Free, always.
+            </p>
+            <SubscribeForm />
+          </Section>
+        </div>
+
+        {showTableOfContents && (
+          <aside className="hidden xl:block">
+            <PostTableOfContents headings={post.headings} />
+          </aside>
+        )}
       </div>
     </PageLayout>
   );

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -18,7 +18,7 @@ import {
   getPostOgMeta,
   getRelatedPosts,
   seriesSlug,
-  slugifyHeading,
+  createHeadingIdGenerator,
 } from '@/utils/posts';
 import { SITE_NAME, SITE_URL, absoluteUrl } from '@/utils/constants';
 
@@ -67,9 +67,10 @@ export default async function PostPage({ params }: PostPageProps) {
   }
   const relatedPosts = getRelatedPosts(post, 3);
   const showTableOfContents = post.headings.length >= 3;
+  const getHeadingId = createHeadingIdGenerator();
   const mdxComponents = {
     h2: ({ children, ...props }: ComponentPropsWithoutRef<'h2'>) => {
-      const id = slugifyHeading(getHeadingText(children));
+      const id = getHeadingId(getHeadingText(children));
       return (
         <h2 {...props} id={id}>
           {children}
@@ -77,7 +78,7 @@ export default async function PostPage({ params }: PostPageProps) {
       );
     },
     h3: ({ children, ...props }: ComponentPropsWithoutRef<'h3'>) => {
-      const id = slugifyHeading(getHeadingText(children));
+      const id = getHeadingId(getHeadingText(children));
       return (
         <h3 {...props} id={id}>
           {children}

--- a/src/components/PostTableOfContents.tsx
+++ b/src/components/PostTableOfContents.tsx
@@ -1,0 +1,92 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+
+import { cn } from '@/utils/helpers';
+import type { PostHeading } from '@/utils/post-taxonomy';
+
+interface PostTableOfContentsProps {
+  headings: PostHeading[];
+}
+
+export default function PostTableOfContents({ headings }: PostTableOfContentsProps) {
+  const headingIds = useMemo(() => headings.map((heading) => heading.id), [headings]);
+  const [activeId, setActiveId] = useState<string | null>(headingIds[0] ?? null);
+
+  useEffect(() => {
+    if (headingIds.length === 0) {
+      return;
+    }
+
+    const observedElements = headingIds
+      .map((id) => document.getElementById(id))
+      .filter((element): element is HTMLElement => Boolean(element));
+
+    if (observedElements.length === 0) {
+      return;
+    }
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        const visibleEntries = entries
+          .filter((entry) => entry.isIntersecting)
+          .sort((a, b) => a.boundingClientRect.top - b.boundingClientRect.top);
+
+        if (visibleEntries.length > 0) {
+          setActiveId(visibleEntries[0]!.target.id);
+        }
+      },
+      {
+        rootMargin: '-20% 0% -65% 0%',
+        threshold: [0, 1],
+      }
+    );
+
+    for (const element of observedElements) {
+      observer.observe(element);
+    }
+
+    return () => {
+      observer.disconnect();
+    };
+  }, [headingIds]);
+
+  if (headings.length === 0) {
+    return null;
+  }
+
+  const resolvedActiveId = activeId ?? headingIds[0] ?? null;
+
+  return (
+    <div className="space-y-3 rounded-3xl border border-white/10 bg-white/[0.03] p-5 xl:sticky xl:top-24">
+      <p className="text-xs uppercase tracking-[0.18em] text-[var(--accent)]">On this page</p>
+      <nav aria-label="Table of contents">
+        <ul className="space-y-2">
+          {headings.map((heading, index) => (
+            <li key={`${heading.id}-${index}`}>
+              <a
+                href={`#${heading.id}`}
+                className={cn(
+                  'a11y-focus-ring block rounded px-2 py-1 text-sm transition',
+                  heading.level === 3 && 'pl-5',
+                  resolvedActiveId === heading.id
+                    ? 'bg-[var(--accent-transparent)] text-[var(--text-primary)]'
+                    : 'text-[var(--text-secondary)] hover:text-[var(--text-primary)]'
+                )}
+              >
+                {heading.text}
+              </a>
+            </li>
+          ))}
+        </ul>
+      </nav>
+      <button
+        type="button"
+        onClick={() => window.scrollTo({ top: 0, behavior: 'smooth' })}
+        className="a11y-focus-ring text-sm font-medium text-[var(--accent)] transition hover:text-[var(--text-primary)]"
+      >
+        Back to top
+      </button>
+    </div>
+  );
+}

--- a/src/utils/post-taxonomy.ts
+++ b/src/utils/post-taxonomy.ts
@@ -27,10 +27,18 @@ export interface PostMeta {
   categoryDescription: string;
   series?: string;
   tags: string[];
+  readingTimeMinutes: number;
+}
+
+export interface PostHeading {
+  id: string;
+  text: string;
+  level: 2 | 3;
 }
 
 export interface Post extends PostMeta {
   content: string;
+  headings: PostHeading[];
 }
 
 export const CATEGORY_ALIASES: Record<string, PostCategory> = {
@@ -115,7 +123,11 @@ export function normalizeCardTitle(data: Record<string, unknown>): string | unde
   return normalizeText(data.shortTitle) ?? normalizeText(data.cardTitle);
 }
 
-export function toPostMeta(slug: string, data: Record<string, unknown>): PostMeta {
+export function toPostMeta(
+  slug: string,
+  data: Record<string, unknown>,
+  readingTimeMinutes: number
+): PostMeta {
   const category = normalizePostCategory(data.category);
   const categoryDetails = getPostCategoryDetails(category);
 
@@ -130,5 +142,6 @@ export function toPostMeta(slug: string, data: Record<string, unknown>): PostMet
     categoryDescription: categoryDetails.description,
     series: normalizePostSeries(data.series),
     tags: normalizePostTags(data.tags),
+    readingTimeMinutes,
   };
 }

--- a/src/utils/posts.test.ts
+++ b/src/utils/posts.test.ts
@@ -1,4 +1,12 @@
-import { getAllPostsMeta, getPostBySlug, getPostOgImageUrl, getPostOgMeta } from '@/utils/posts';
+import {
+  extractPostHeadings,
+  getAllPostsMeta,
+  getPostBySlug,
+  getPostOgImageUrl,
+  getPostOgMeta,
+  getReadingTimeFromContent,
+  getRelatedPosts,
+} from '@/utils/posts';
 import { POST_CATEGORIES } from '@/utils/post-taxonomy';
 
 describe('posts utilities', () => {
@@ -29,6 +37,8 @@ describe('posts utilities', () => {
     expect(firstPost?.title).toBe(posts[0]!.title);
     expect(firstPost?.categoryLabel).toBe(posts[0]!.categoryLabel);
     expect(Array.isArray(firstPost?.tags)).toBe(true);
+    expect(posts[0]?.readingTimeMinutes).toBeGreaterThan(0);
+    expect(firstPost?.headings.length).toBeGreaterThanOrEqual(0);
   });
 
   it('categorizes the recent March Daily Word posts correctly', async () => {
@@ -77,5 +87,44 @@ describe('posts utilities', () => {
 
   it('all posts have valid frontmatter', () => {
     expect(() => getAllPostsMeta({ includeFuture: true })).not.toThrow();
+  });
+
+  it('extracts headings and reading time from mdx content', () => {
+    const content = `---
+title: "Sample"
+date: "2026-04-05"
+excerpt: "Sample excerpt"
+category: "Daily Word"
+---
+
+## First Heading
+
+Some words in a paragraph.
+
+### Child Heading
+
+\`\`\`ts
+const hidden = "code block should not count";
+\`\`\`
+`;
+
+    expect(getReadingTimeFromContent(content)).toBe(1);
+    expect(extractPostHeadings(content)).toEqual([
+      { id: 'first-heading', text: 'First Heading', level: 2 },
+      { id: 'child-heading', text: 'Child Heading', level: 3 },
+    ]);
+  });
+
+  it('returns up to three related posts prioritized by category and tags', () => {
+    const posts = getAllPostsMeta();
+    const sourcePost = posts.find((post) => post.tags.length > 0) ?? posts[0];
+    expect(sourcePost).toBeDefined();
+    if (!sourcePost) {
+      throw new Error('Expected at least one post');
+    }
+
+    const related = getRelatedPosts(sourcePost);
+    expect(related.length).toBeLessThanOrEqual(3);
+    expect(related.some((post) => post.slug === sourcePost.slug)).toBe(false);
   });
 });

--- a/src/utils/posts.test.ts
+++ b/src/utils/posts.test.ts
@@ -115,6 +115,18 @@ const hidden = "code block should not count";
     ]);
   });
 
+  it('deduplicates repeated heading ids in order', () => {
+    const content = `## Takeaway
+### Takeaway
+## Takeaway`;
+
+    expect(extractPostHeadings(content)).toEqual([
+      { id: 'takeaway', text: 'Takeaway', level: 2 },
+      { id: 'takeaway-2', text: 'Takeaway', level: 3 },
+      { id: 'takeaway-3', text: 'Takeaway', level: 2 },
+    ]);
+  });
+
   it('returns up to three related posts prioritized by category and tags', () => {
     const posts = getAllPostsMeta();
     const sourcePost = posts.find((post) => post.tags.length > 0) ?? posts[0];

--- a/src/utils/posts.ts
+++ b/src/utils/posts.ts
@@ -132,11 +132,23 @@ export function slugifyHeading(value: string): string {
   return slug || 'section';
 }
 
+export function createHeadingIdGenerator() {
+  const slugCount = new Map<string, number>();
+
+  return (value: string): string => {
+    const baseId = slugifyHeading(value);
+    const count = (slugCount.get(baseId) ?? 0) + 1;
+    slugCount.set(baseId, count);
+    return count === 1 ? baseId : `${baseId}-${count}`;
+  };
+}
+
 export function extractPostHeadings(content: string): PostHeading[] {
   const withoutFrontmatter = stripMdxFrontmatter(content);
   const withoutCodeBlocks = stripMdxCodeFences(withoutFrontmatter);
   const lines = withoutCodeBlocks.split('\n');
   const headings: PostHeading[] = [];
+  const getHeadingId = createHeadingIdGenerator();
 
   for (const line of lines) {
     const match = /^(#{2,3})\s+(.+?)\s*#*\s*$/.exec(line);
@@ -151,7 +163,7 @@ export function extractPostHeadings(content: string): PostHeading[] {
     }
 
     headings.push({
-      id: slugifyHeading(text),
+      id: getHeadingId(text),
       text,
       level,
     });

--- a/src/utils/posts.ts
+++ b/src/utils/posts.ts
@@ -5,7 +5,7 @@ import path from 'path';
 import matter from 'gray-matter';
 import yaml from 'js-yaml';
 
-import { Post, PostMeta, toPostMeta } from '@/utils/post-taxonomy';
+import { Post, PostHeading, PostMeta, toPostMeta } from '@/utils/post-taxonomy';
 import { frontmatterSchema } from '@/utils/frontmatter-schema';
 import { absoluteUrl } from '@/utils/constants';
 
@@ -94,12 +94,84 @@ type ParsedPostEntry = {
   slug: string;
   meta: PostMeta;
   content: string;
+  headings: PostHeading[];
 };
 type PostsCache = {
   signature: string;
   posts: ParsedPostEntry[];
 };
 let postsCache: PostsCache | null = null;
+const WORDS_PER_MINUTE = 200;
+
+function stripMdxFrontmatter(value: string): string {
+  return value.replace(/^---[\s\S]*?---\s*/, '');
+}
+
+function stripMdxCodeFences(value: string): string {
+  return value.replace(/```[\s\S]*?```/g, ' ');
+}
+
+function normalizeHeadingText(value: string): string {
+  return value
+    .replace(/!\[[^\]]*]\([^)]*\)/g, ' ')
+    .replace(/\[([^\]]+)\]\([^)]*\)/g, '$1')
+    .replace(/`([^`]+)`/g, '$1')
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+export function slugifyHeading(value: string): string {
+  const slug = value
+    .toLowerCase()
+    .normalize('NFKD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/[^a-z0-9\s-]/g, '')
+    .trim()
+    .replace(/\s+/g, '-');
+  return slug || 'section';
+}
+
+export function extractPostHeadings(content: string): PostHeading[] {
+  const withoutFrontmatter = stripMdxFrontmatter(content);
+  const withoutCodeBlocks = stripMdxCodeFences(withoutFrontmatter);
+  const lines = withoutCodeBlocks.split('\n');
+  const headings: PostHeading[] = [];
+
+  for (const line of lines) {
+    const match = /^(#{2,3})\s+(.+?)\s*#*\s*$/.exec(line);
+    if (!match) {
+      continue;
+    }
+
+    const level = match[1]!.length as 2 | 3;
+    const text = normalizeHeadingText(match[2]!);
+    if (!text) {
+      continue;
+    }
+
+    headings.push({
+      id: slugifyHeading(text),
+      text,
+      level,
+    });
+  }
+
+  return headings;
+}
+
+export function getReadingTimeFromContent(content: string): number {
+  const plainText = stripMdxCodeFences(stripMdxFrontmatter(content))
+    .replace(/!\[[^\]]*]\([^)]*\)/g, ' ')
+    .replace(/\[([^\]]+)\]\([^)]*\)/g, '$1')
+    .replace(/`([^`]+)`/g, '$1')
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/[#>*_~[\](){}|\\/-]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+  const wordCount = plainText ? plainText.split(' ').length : 0;
+  return Math.max(1, Math.ceil(wordCount / WORDS_PER_MINUTE));
+}
 
 function ensurePostsDir() {
   if (!fs.existsSync(POSTS_DIR)) {
@@ -151,10 +223,14 @@ function getParsedPosts(): ParsedPostEntry[] {
         throw new Error(`Frontmatter validation failed for "${slug}.mdx":\n${issues}`);
       }
 
+      const readingTimeMinutes = getReadingTimeFromContent(content);
+      const headings = extractPostHeadings(content);
+
       return {
         slug,
-        meta: toPostMeta(slug, data),
+        meta: toPostMeta(slug, result.data, readingTimeMinutes),
         content,
+        headings,
       };
     });
 
@@ -194,13 +270,65 @@ export async function getPostBySlug(
   if (!parsedPost) {
     return null;
   }
-  const post = { ...parsedPost.meta, content: parsedPost.content };
+  const post = {
+    ...parsedPost.meta,
+    content: parsedPost.content,
+    headings: parsedPost.headings,
+  };
 
   if (!includeFuture && !isPublishedDate(post.date)) {
     return null;
   }
 
   return post;
+}
+
+export function getRelatedPosts(
+  post: Pick<PostMeta, 'slug' | 'category' | 'tags'>,
+  limit = 3
+): PostMeta[] {
+  const candidates = getAllPostsMeta().filter((candidate) => candidate.slug !== post.slug);
+  const normalizedPostTags = new Set(post.tags.map((tag) => tag.toLowerCase()));
+
+  const primaryMatches = candidates
+    .map((candidate) => {
+      const sharedTagCount = candidate.tags.reduce((count, tag) => {
+        return normalizedPostTags.has(tag.toLowerCase()) ? count + 1 : count;
+      }, 0);
+      const sameCategory = candidate.category === post.category;
+      const score = (sameCategory ? 2 : 0) + sharedTagCount * 3;
+
+      return {
+        candidate,
+        score,
+        sharedTagCount,
+      };
+    })
+    .filter((item) => item.score > 0)
+    .sort((a, b) => {
+      if (a.score !== b.score) {
+        return b.score - a.score;
+      }
+      if (a.sharedTagCount !== b.sharedTagCount) {
+        return b.sharedTagCount - a.sharedTagCount;
+      }
+      return b.candidate.date.localeCompare(a.candidate.date);
+    })
+    .map((item) => item.candidate);
+
+  const related = [...primaryMatches];
+
+  for (const candidate of candidates) {
+    if (related.length >= limit) {
+      break;
+    }
+    if (related.some((relatedPost) => relatedPost.slug === candidate.slug)) {
+      continue;
+    }
+    related.push(candidate);
+  }
+
+  return related.slice(0, limit);
 }
 
 export function getPostOgImageUrl(slug: string): string {


### PR DESCRIPTION
## Summary
- Add heading extraction and slug generation for MDX posts, plus computed reading time stored in post metadata.
- Render an in-post table of contents with active-section tracking and a back-to-top link for posts with enough headings.
- Replace category-only recommendations with scored related posts based on shared category and tags.
- Expand post utility tests to cover heading parsing, reading time, and related-post selection.

## Testing
- `pnpm test src/utils/posts.test.ts`
- `pnpm lint`
- Not run: full production build