### PR TITLE
fix(dev): stable next dev with Watchpack polling

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "packageManager": "pnpm@10.15.0",
   "scripts": {
-    "dev": "next dev",
+    "dev": "WATCHPACK_POLLING=true next dev",
     "build": "next build",
     "start": "next start",
     "lint": "eslint src scripts",


### PR DESCRIPTION
## Problem

`pnpm dev` could hit Watchpack `EMFILE: too many open files, watch` in constrained environments. When that happened, Next only compiled `/_not-found`, so real routes (`/ `, `/blog`, post slugs) returned **404** even though `pnpm build` + `pnpm start` were fine.

## Change

- Set `WATCHPACK_POLLING=true` in the `dev` script so the dev server uses polling watchers instead of relying on native watch descriptors.

## Verification (this session)

- `pnpm lint` — pass
- `pnpm test` — 13 suites, 90 tests, pass
- `pnpm build` — pass
- Manual: `pnpm dev` + `curl` to `/`, `/blog`, latest post slug — **200** with expected content

## Trade-off

Polling uses more CPU than native watches; acceptable for local dev reliability. Anyone who prefers native watches can run `next dev` directly or override the script locally.

Made with [Cursor](https://cursor.com)