### PR TITLE
Devotion: Hosanna Means Save Us Now

### DIFF
--- a/src/posts/2026-04-28-hosanna-means-save-us-now.mdx
+++ b/src/posts/2026-04-28-hosanna-means-save-us-now.mdx
@@ -13,20 +13,20 @@ tags:
 
 > Hosanna: Blessed is the King of Israel that cometh in the name of the Lord. — John 12:13 (KJV)
 
-The word "hosanna" is a cry, not a cheer. It comes from a Hebrew phrase meaning "save us now" or "save, please." The crowd waving palm branches wasn't just celebrating. They were begging. They had waited their whole lives for someone to fix what was broken, and here He came.
+"Hosanna" is a cry — a Hebrew plea meaning "save us now." The crowd waving palm branches wasn't just celebrating. They were begging. They had waited their whole lives for someone to fix what was broken, and here He came.
 
 ## The Crowd Got It Half Right
 
-Palm branches in Jewish tradition symbolized military victory. The crowd was reading the moment the way they'd been trained to read it. A king arrives, you wave palms, you shout for rescue, you expect him to take the throne, call up an army, drive out Rome. That's what they wanted. That's not what they got.
+Palm branches in Jewish tradition symbolized military victory. The crowd was reading the moment the way they'd been trained to read it. A king arrives, you wave palms, you shout for rescue, you expect him to take the throne, call up an army, drive out Rome. They expected a sword. They got a cross.
 
-Jesus knew this when He rode in. He saw the crowd, heard the hosannas, and knew that within a week most of them would be calling for His crucifixion. He rode in anyway. Not naive, not deceived. Clear-eyed about what was coming, and coming because love doesn't wait until conditions are favorable.
+Jesus knew this when He rode in. He saw the crowd, heard the hosannas, and knew that within a week most of them would be calling for His crucifixion. He rode in anyway. Clear-eyed about what was coming, and coming because love doesn't wait until conditions are favorable.
 
-## Who You're Actually Worshiping
+## Are You Worshiping Jesus as He Is?
 
-The harder question the crowd's mistake forces on you is this: are you worshiping Jesus as He is, or as you want Him to be?
+Are you worshiping Jesus as He is, or as you want Him to be?
 
-It's easy to celebrate when He seems to be moving in the direction you hoped. The real test is when He doesn't. When the answer is no, when the healing doesn't come, when the situation gets worse before it gets better.
+Celebrating feels natural when He moves the direction you hoped. The real test is when He doesn't. When the answer is no, when the healing doesn't come, when the situation gets worse before it gets better.
 
 The crowd shouted "Hosanna" and then felt cheated when He chose the cross over the sword. But the cross was the only thing that could actually save them. They asked for the right thing with the wrong picture in their heads.
 
-Come into worship today with real longing. That's not wrong. That's exactly what Jesus rode toward. Just be honest about who He actually is, not only the version of Him that makes life easier. The rescue He has planned is better than the one you're imagining.
+Come into worship today with real longing. That's exactly what Jesus rode toward. Just be honest about who He actually is, not only the version of Him that makes life easier. The rescue He has planned is better than the one you're imagining.

--- a/src/posts/2026-04-28-hosanna-means-save-us-now.mdx
+++ b/src/posts/2026-04-28-hosanna-means-save-us-now.mdx
@@ -1,0 +1,32 @@
+---
+title: 'Hosanna Means Save Us Now'
+date: '2026-04-28'
+excerpt: '"Hosanna" was not a cheer. It was a cry. The crowd in Jerusalem was begging for rescue, and they were right to beg. They just had the wrong picture of how the rescue would come.'
+category: 'Daily Word'
+series: 'The King Who Came Humble and Changed Everything'
+tags:
+  - 'John 12'
+  - 'Palm Sunday'
+  - 'Worship'
+  - 'Surrender'
+---
+
+> Hosanna: Blessed is the King of Israel that cometh in the name of the Lord. — John 12:13 (KJV)
+
+The word "hosanna" is a cry, not a cheer. It comes from a Hebrew phrase meaning "save us now" or "save, please." The crowd waving palm branches wasn't just celebrating. They were begging. They had waited their whole lives for someone to fix what was broken, and here He came.
+
+## The Crowd Got It Half Right
+
+Palm branches in Jewish tradition symbolized military victory. The crowd was reading the moment the way they'd been trained to read it. A king arrives, you wave palms, you shout for rescue, you expect him to take the throne, call up an army, drive out Rome. That's what they wanted. That's not what they got.
+
+Jesus knew this when He rode in. He saw the crowd, heard the hosannas, and knew that within a week most of them would be calling for His crucifixion. He rode in anyway. Not naive, not deceived. Clear-eyed about what was coming, and coming because love doesn't wait until conditions are favorable.
+
+## Who You're Actually Worshiping
+
+The harder question the crowd's mistake forces on you is this: are you worshiping Jesus as He is, or as you want Him to be?
+
+It's easy to celebrate when He seems to be moving in the direction you hoped. The real test is when He doesn't. When the answer is no, when the healing doesn't come, when the situation gets worse before it gets better.
+
+The crowd shouted "Hosanna" and then felt cheated when He chose the cross over the sword. But the cross was the only thing that could actually save them. They asked for the right thing with the wrong picture in their heads.
+
+Come into worship today with real longing. That's not wrong. That's exactly what Jesus rode toward. Just be honest about who He actually is, not only the version of Him that makes life easier. The rescue He has planned is better than the one you're imagining.


### PR DESCRIPTION
## Daily Devotion — 2026-04-28

**Source:** Lesson 09 — The King Who Came Humble and Changed Everything (Tuesday entry)

> "Hosanna" was not a cheer. It was a cry. The crowd in Jerusalem was begging for rescue, and they were right to beg. They just had the wrong picture of how the rescue would come.

---
Once merged, the devotion-broadcast workflow will automatically send this to The Daily Word subscribers via ConvertKit.
