### PR TITLE
Update field notes subscription plans

### DIFF
--- a/src/data/field-notes.ts
+++ b/src/data/field-notes.ts
@@ -5,7 +5,7 @@
  */
 
 /** ISO date — bump when you revise items or copy. Shown on `/field-notes`. */
-export const fieldNotesLastUpdated = '2026-04-18';
+export const fieldNotesLastUpdated = '2026-04-27';
 
 export type FieldNoteStatus = 'using' | 'trying';
 
@@ -34,13 +34,13 @@ export const fieldNotesSections: FieldNoteSection[] = [
     items: [
       {
         title: 'Claude (desktop)',
-        tags: ['anthropic', 'Pro $20/mo'],
+        tags: ['anthropic', 'Max 5x $100/mo'],
         badge: 'daily',
-        note: 'Cowork and Claude Code inside the desktop app. On Pro; I use it heavily.',
+        note: 'Cowork and Claude Code inside the desktop app. On Max; I use it heavily.',
       },
       {
         title: 'Warp',
-        tags: ['terminal', 'Builder $20/mo'],
+        tags: ['terminal', 'Build $20/mo'],
         badge: 'daily',
         note: 'My terminal. Oz, Codex sessions, and the occasional Claude Code CLI run all happen here.',
         link: { href: 'https://app.warp.dev/referral/3MJVPD', label: 'my referral' },


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Claude tag updated from `Pro $20/mo` → `Max 5x $100/mo`; note text updated from "On Pro" → "On Max"
- Warp tag corrected from `Builder $20/mo` → `Build $20/mo` (Warp renamed their $20/mo tier to "Build" in 2026)
- Bumped `fieldNotesLastUpdated` to `2026-04-27`

## Test plan

- [x] Visit `/field-notes` and confirm Claude shows "Max 5x $100/mo" tag and "On Max" in the note
- [x] Confirm Warp shows "Build $20/mo" tag
- [x] Confirm last-updated date reads April 27, 2026

https://claude.ai/code/session_01MqwZmn4FoJT56sBx7G6QAA
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MqwZmn4FoJT56sBx7G6QAA)_