### PR TITLE
chore(deps): phase 1 patch bumps

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "react": "^19.2.5",
     "react-confetti": "^6.4.0",
     "react-dom": "^19.2.5",
-    "react-qr-code": "^2.0.15",
+    "react-qr-code": "^2.0.20",
     "rehype-autolink-headings": "^7.1.0",
     "rehype-slug": "^6.0.0",
     "remark-gfm": "^4.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,8 +71,8 @@ importers:
         specifier: ^19.2.5
         version: 19.2.5(react@19.2.5)
       react-qr-code:
-        specifier: ^2.0.15
-        version: 2.0.18(react@19.2.5)
+        specifier: ^2.0.20
+        version: 2.0.20(react@19.2.5)
       rehype-autolink-headings:
         specifier: ^7.1.0
         version: 7.1.0
@@ -4078,8 +4078,8 @@ packages:
   react-is@18.3.1:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
 
-  react-qr-code@2.0.18:
-    resolution: {integrity: sha512-v1Jqz7urLMhkO6jkgJuBYhnqvXagzceg3qJUWayuCK/c6LTIonpWbwxR1f1APGd4xrW/QcQEovNrAojbUz65Tg==}
+  react-qr-code@2.0.20:
+    resolution: {integrity: sha512-I7hTe6LBRMU35gQ2Ypsk2LIXZN6iq6Ad9axDj2cuHO+mtbtGIMC1gl2mhwDtPYUX/a7zHrGhsAt6Kifil2ujsA==}
     peerDependencies:
       react: '*'
 
@@ -9692,7 +9692,7 @@ snapshots:
 
   react-is@18.3.1: {}
 
-  react-qr-code@2.0.18(react@19.2.5):
+  react-qr-code@2.0.20(react@19.2.5):
     dependencies:
       prop-types: 15.8.1
       qr.js: 0.0.0

--- a/src/components/TipJar.tsx
+++ b/src/components/TipJar.tsx
@@ -6,7 +6,7 @@ import { useState, useEffect, useRef } from 'react';
 import { PRESET_AMOUNTS } from '@/utils/tipjar';
 
 const ReactConfetti = dynamic(() => import('react-confetti'), { ssr: false });
-const QRCode = dynamic(() => import('react-qr-code'), { ssr: false });
+const QRCode = dynamic(() => import('react-qr-code').then((mod) => mod.QRCode), { ssr: false });
 
 type TipJarState = 'select' | 'pay' | 'success';
 type AmountOption = (typeof PRESET_AMOUNTS)[number] | 'custom';


### PR DESCRIPTION
## Summary
- Bump postcss 8.5.10 → 8.5.12, react-qr-code 2.0.18 → 2.0.20, and typescript-eslint trio 8.59.0 → 8.59.1
- Fix `TipJar.tsx` dynamic import: react-qr-code 2.0.20 dropped the default export from its types, so pull `mod.QRCode` instead

Phase 1 of three planned upgrade phases (patches → ESLint 10 → Tailwind 4).

## Test plan
- [x] `pnpm lint`
- [x] `pnpm test` (117 tests pass)
- [x] `pnpm build`
- [x] Vercel preview loads `/support` page and renders QR code on Tip Jar
- [x] Lighthouse workflow stays green

🤖 Generated with [Claude Code](https://claude.com/claude-code)