### PR TITLE
fix(daily-word): keep Current Series pill cohesive when text wraps

### DIFF
--- a/src/app/daily-word/page.tsx
+++ b/src/app/daily-word/page.tsx
@@ -42,7 +42,7 @@ export default function DailyWordPage() {
 
         {currentSeries && (
           <div className="mt-5">
-            <span className="rounded-full border border-(--accent-border) bg-(--accent-transparent) px-4 py-1.5 text-xs uppercase tracking-[0.18em] text-(--accent)">
+            <span className="inline-block rounded-2xl border border-(--accent-border) bg-(--accent-transparent) px-4 py-1.5 text-xs uppercase tracking-[0.18em] text-(--accent)">
               Current Series: {currentSeries}
             </span>
           </div>


### PR DESCRIPTION
## Summary

Reported from iPhone 17: the **Current Series** badge on `/daily-word` looked like overlapping/stacked highlight boxes whenever the series title was long enough to wrap.

The badge was an inline `<span>` with `rounded-full`. When inline content breaks across lines, browsers paint the background and border per line fragment, so the rounded pill ends doubled up where the line broke. Other chips on the site escape this because they live inside `flex flex-wrap` containers (flex items render as block-level), but this one sat in a plain `<div>`.

Fix: make the pill `inline-block` and switch `rounded-full` → `rounded-2xl`. Now the whole pill wraps as one cohesive unit, and the text inside can break cleanly without painting a second background fragment.

## Test plan

- [ ] On iPhone 17 (or any narrow viewport), open `/daily-word` and confirm the "Current Series: …" pill renders as a single rounded box even when the series title wraps to two lines.
- [ ] Verify light + dark and orange + green theme variants.
- [ ] Confirm the pill still looks right on wider viewports where the text fits on one line.

## Notes (not addressed here)

The header nav also wraps to two lines on narrow viewports (5 items + 2 items, with the second row centered). That's expected wrapping behavior given seven nav items — happy to tighten the labels or drop one if you'd like a follow-up.

https://claude.ai/code/session_01PV7SaoTUDfEg1uhoVRCXxn

---
_Generated by [Claude Code](https://claude.ai/code/session_01PV7SaoTUDfEg1uhoVRCXxn)_