### PR TITLE
Rename /projects → /portfolio

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This repo uses pnpm pinned via Corepack (see package.json "packageManager").
 
 - ⚡ Built with Next.js 14+ (App Router), React, and Tailwind CSS
 - 📝 Custom blog with MDX support and syntax highlighting
-- 💻 Projects page with detailed tech stack and features
+- 💻 Portfolio page (`/portfolio`) with detailed tech stack and features
 - 🎤 Talks & sermons archive
 - ⚡ Lightning Network integration for tips and donations
 - 🌗 Responsive design with dark mode support
@@ -30,7 +30,7 @@ personal-site/
 │   │   ├── api/                # API routes
 │   │   ├── blog/               # Blog post pages
 │   │   ├── bitcoin/            # Bitcoin resources
-│   │   ├── projects/           # Projects showcase
+│   │   ├── portfolio/          # Portfolio showcase (was /projects)
 │   │   ├── support/            # Support/tipping page
 │   │   ├── talks/              # Talks and sermons
 │   │   └── ...                 # Other routes and configs

--- a/next.config.js
+++ b/next.config.js
@@ -9,6 +9,7 @@ const nextConfig = {
     return [
       { source: '/notebook', destination: '/field-notes', permanent: true },
       { source: '/state-of-ai', destination: '/field-notes', permanent: true },
+      { source: '/projects', destination: '/portfolio', permanent: true },
     ];
   },
   async headers() {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -139,8 +139,8 @@ export default async function Home() {
           />
           <LinkCard
             key="my-projects"
-            title="Projects & Contributions"
-            href="/projects"
+            title="Portfolio"
+            href="/portfolio"
             icon={<span className="text-2xl">🚀</span>}
             eyebrow="Portfolio"
             meta="Software and experiments"

--- a/src/app/portfolio/page.tsx
+++ b/src/app/portfolio/page.tsx
@@ -13,22 +13,22 @@ import {
 import { SITE_NAME } from '@/utils/constants';
 
 export const metadata: Metadata = {
-  title: 'Projects & Contributions',
+  title: 'Portfolio',
   description: `Explore Brandon's projects and open-source contributions.`,
   alternates: {
-    canonical: '/projects',
+    canonical: '/portfolio',
   },
   openGraph: {
-    title: 'Projects',
+    title: 'Portfolio',
     description: `Explore Brandon's projects, apps, and experiments.`,
-    url: '/projects',
+    url: '/portfolio',
     type: 'website',
     images: [
       {
         url: '/family-photo.jpeg',
         width: 1024,
         height: 1024,
-        alt: `${SITE_NAME} - Projects`,
+        alt: `${SITE_NAME} - Portfolio`,
       },
     ],
   },
@@ -82,7 +82,7 @@ function ProjectCard({ project }: { project: Project }) {
   );
 }
 
-export default function Projects() {
+export default function Portfolio() {
   const grouped = GROUP_ORDER.map((group) => ({
     group,
     label: projectGroupLabels[group],
@@ -90,7 +90,7 @@ export default function Projects() {
   })).filter((g) => g.items.length > 0);
 
   return (
-    <PageLayout title="Projects & Contributions">
+    <PageLayout title="Portfolio">
       <section className="flex flex-col gap-10 items-center min-h-[40vh]">
         {grouped.map(({ group, label, items }) => (
           <div key={group} className="w-full max-w-xl">

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -83,7 +83,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
       priority: 0.5,
     },
     {
-      url: absoluteUrl('/projects'),
+      url: absoluteUrl('/portfolio'),
       lastModified: new Date(),
       changeFrequency: 'monthly',
       priority: 0.55,

--- a/src/config/site-nav.ts
+++ b/src/config/site-nav.ts
@@ -29,7 +29,7 @@ export function getSiteNavItems({ latestSlug }: { latestSlug: string | null }): 
     items.push({ href: `/blog/${latestSlug}`, label: 'Latest', match: 'exact' });
   }
   items.push(
-    { href: '/projects', label: 'Projects', match: 'exact' },
+    { href: '/portfolio', label: 'Portfolio', match: 'exact' },
     { href: '/field-notes', label: 'Field notes', match: 'exact' },
     { href: '/bitcoin', label: 'Bitcoin', match: 'exact' },
     { href: '/daily-word', label: 'Daily Word', match: 'exact' },

--- a/src/data/projects.ts
+++ b/src/data/projects.ts
@@ -1,5 +1,5 @@
 /**
- * Portfolio data (`/projects`) — apps, tools, OSS contributions, and talks.
+ * Portfolio data (`/portfolio`) — apps, tools, OSS contributions, and talks.
  * Edit here to update copy. Bump `projectsLastUpdated` when you revise.
  */
 


### PR DESCRIPTION
## Summary
- Rename `src/app/projects/` → `src/app/portfolio/` so the URL reads as a resume-link (`saucy.tech/portfolio`).
- Update internal refs: home card, sitemap, site-nav (label + href → "Portfolio"), data comment, architecture-map doc, README.
- Add 308 permanent redirect `/projects` → `/portfolio` in `next.config.js` so existing links/SEO carry over.

## Test plan
- [x] `pnpm lint` clean
- [x] `pnpm test` — 117/117 pass
- [x] `curl -I /projects` → 308 with `location: /portfolio`
- [x] `/portfolio` renders 200, page title "Portfolio", nav + footer show "Portfolio"
- [x] No browser console errors
- [x] Deploy preview spot-check on Vercel

🤖 Generated with [Claude Code](https://claude.com/claude-code)