### PR TITLE
Devotion: The Weight of a Meal

### DIFF
--- a/src/posts/2026-05-04-the-weight-of-a-meal.mdx
+++ b/src/posts/2026-05-04-the-weight-of-a-meal.mdx
@@ -1,0 +1,33 @@
+---
+title: 'The Weight of a Meal'
+date: '2026-05-04'
+excerpt: 'For fourteen hundred years, Israel had observed the Passover. Then Jesus sat down at one final table and changed what a meal could mean.'
+category: 'Daily Word'
+series: 'When He Chose the Table Over Everything'
+tags:
+  - 'Luke 22'
+  - 'Exodus 12'
+  - 'Passover'
+  - 'Covenant'
+  - 'Remembrance'
+---
+
+> And he took bread, and gave thanks, and brake it, and gave it unto them, saying, This is my body which is given for you: this do in remembrance of me. — Luke 22:19 (KJV)
+
+For fourteen hundred years, Israel had observed the Passover. A meal. A remembrance. Blood on the doorposts that meant the difference between death and deliverance. By the time Jesus sat down at that final table, the ritual had been kept so many times it could be performed half-asleep. Lamb. Bread. Bitter herbs. The same words. The same posture. The same story.
+
+But when Jesus took the bread that night, He didn't dismiss what the meal had been. He fulfilled it. The covenant that had marked Israel's doorposts was about to be carried in His body. The blood that had once stayed the angel of death was about to be poured out for the world.
+
+## What a Meal Can Carry
+
+Most meals don't ask much of you. You eat, you talk, you move on. But some meals carry weight that the calories never account for. The dinner the night before someone deploys. The breakfast after a long hospital vigil. The communion plate, passed down a row, with bread small enough to miss if you weren't paying attention.
+
+Jesus didn't choose a sermon for His final night. He didn't write a treatise. He chose a table. He took the most ordinary thing humans do, eating together, and made it the place where heaven and earth were sealed in covenant.
+
+## The Question Behind the Meal
+
+How many meals do you eat that you've stopped really seeing? Not just communion. Any of them. The dinner with your kids. The coffee with a friend who's been carrying something heavy. The morning bread you grab without thinking.
+
+Some moments should change us. Some tables hold more than what's served on them. The meal Jesus chose to leave us was not a private ceremony for clergy and saints. It was bread and a cup, given to anyone willing to remember.
+
+What's a meal in your own life that has lost its weight? What if today, you sat down to it like it mattered?


### PR DESCRIPTION
## Daily Devotion — 2026-05-04

**Source:** Lesson 10 — When He Chose the Table Over Everything (Monday entry)

> For fourteen hundred years, Israel had observed the Passover. Then Jesus sat down at one final table and changed what a meal could mean.

---
Once merged, the devotion-broadcast workflow will automatically send this to The Daily Word subscribers via ConvertKit.
