### PR TITLE
Devotion: Already Waiting

### DIFF
--- a/src/posts/2026-05-05-already-waiting.mdx
+++ b/src/posts/2026-05-05-already-waiting.mdx
@@ -1,0 +1,37 @@
+---
+title: 'Already Waiting'
+date: '2026-05-05'
+excerpt: 'The room was prepared before Peter and John ever arrived. Jesus was wanting that meal long before His friends knew where they would be eating.'
+category: 'Daily Word'
+series: 'When He Chose the Table Over Everything'
+tags:
+  - 'Luke 22'
+  - 'Communion'
+  - 'Prayer'
+  - 'Desire'
+  - 'Belonging'
+---
+
+> And he said unto them, With desire I have desired to eat this passover with you before I suffer. — Luke 22:15 (KJV)
+
+Peter and John get one of the strangest assignments in scripture. Find a man carrying a water jar. Follow him. He'll lead you to a house. The owner will already be expecting you. The room will already be prepared.
+
+No name. No address. No explanation. Just trust.
+
+What makes the story remarkable isn't the cloak-and-dagger logistics. It's that everything was ready before the disciples got there. The room. The host. The table. The bread. Jesus had set this in motion long before His friends knew where they'd be eating. He had been planning this meal, this moment, while they were still arguing about who was greatest.
+
+## The Desire That Came First
+
+Then He sits down and says it plainly: *With desire I have desired to eat this passover with you.*
+
+Not obligation. Not duty. Not "since the calendar says I must." Desire. He wanted this. He wanted to be in that room, with those people, on that night. He wanted it before they wanted it. He wanted it knowing exactly what was coming next.
+
+We tend to live our spiritual lives the wrong way around. We try to convince God to want us. We bring our offerings, sharpen our prayers, tidy our resumes, and hope it's enough to win some warmth from heaven. The whole posture is built on a quiet fear that, left to His own preferences, He'd rather not bother.
+
+## What If He's Already There
+
+The upper room was prepared before Peter and John ever arrived. The Father had been wanting this meal since before the foundation of the world. He has, in every way that matters, been the first to show up.
+
+If you knew prayer wasn't an interruption, that the table was already set, the room already prepared, the desire already burning on His side before yours, how would you walk in?
+
+You don't have to convince Him you belong. He arranged the room.


### PR DESCRIPTION
## Daily Devotion — 2026-05-05

**Source:** Lesson 10 — When He Chose the Table Over Everything (Tuesday entry)

> The room was prepared before Peter and John ever arrived. Jesus was wanting that meal long before His friends knew where they would be eating.

---
Once merged, the devotion-broadcast workflow will automatically send this to The Daily Word subscribers via ConvertKit.
