### PR TITLE
Devotion: The Argument After the Bread

### DIFF
--- a/src/posts/2026-05-07-the-argument-after-the-bread.mdx
+++ b/src/posts/2026-05-07-the-argument-after-the-bread.mdx
@@ -1,0 +1,34 @@
+---
+title: 'The Argument After the Bread'
+date: '2026-05-07'
+excerpt: 'They had just shared the cup. The bread had just passed between them. And then they started arguing about who was greatest. Jesus answered with the smallest word in the room.'
+category: 'Daily Word'
+series: 'When He Chose the Table Over Everything'
+tags:
+  - 'Luke 22'
+  - 'Service'
+  - 'Greatness'
+  - 'Humility'
+---
+
+> For whether is greater, he that sitteth at meat, or he that serveth? is not he that sitteth at meat? but I am among you as he that serveth. — Luke 22:27 (KJV)
+
+The bread had just been broken. The cup had just been passed. The covenant Jesus had been carrying for centuries was finally on the table between them. And the disciples, sitting in the holiest room any of them would ever enter, started arguing about which one of them was the greatest.
+
+Read that twice. The Last Supper is happening, and they are jockeying for position.
+
+It is tempting to scoff. But honest reflection says we sit at the same table they did. We come to the bread and the cup with a quiet calculation still running in the back of our minds. Who is noticed. Who is ahead. Who matters. The argument they had out loud is the one we tend to keep quiet.
+
+## The Reversal Jesus Made
+
+Jesus does not shame them. He gives them a different math. *"The kings of the Gentiles exercise lordship over them; and they that exercise authority upon them are called benefactors. But ye shall not be so."* The world's ladder gets inverted at His table. Greatness is not how many people serve you. It is how many people you have served when nobody was counting.
+
+Then He says it plainly: *"I am among you as he that serveth."* The One who could have demanded the head seat took the towel.
+
+## What Greatness Looks Like Now
+
+Picture the people who have shaped your faith the most. The ones whose names show up in your prayers. Almost none of them held the platforms. They held the door. They cooked the meal. They sat with you when you were unraveling. They were great because they served, and they served because they had stopped competing.
+
+That is the kingdom Jesus opened at that table. A kingdom where the towel outranks the throne, where the smallest service done in love carries more weight than the largest reputation built without it.
+
+Where are you still measuring your worth by what you have accomplished instead of by who you have quietly carried? What would change today if you stopped counting and started serving?


### PR DESCRIPTION
## Daily Devotion — 2026-05-07

**Source:** Lesson 10 — When He Chose the Table Over Everything (Thursday entry)

> They had just shared the cup. The bread had just passed between them. And then they started arguing about who was greatest. Jesus answered with the smallest word in the room.

---
Once merged, the devotion-broadcast workflow will automatically send this to The Daily Word subscribers via ConvertKit.
