### PR TITLE
Devotion: Till He Come

### DIFF
--- a/src/posts/2026-05-08-till-he-come.mdx
+++ b/src/posts/2026-05-08-till-he-come.mdx
@@ -1,0 +1,33 @@
+---
+title: 'Till He Come'
+date: '2026-05-08'
+excerpt: 'Communion is usually treated like a rearview mirror. Paul slips a phrase into the middle of his instruction that almost no one stops on: till he come.'
+category: 'Daily Word'
+series: 'When He Chose the Table Over Everything'
+tags:
+  - '1 Corinthians 11'
+  - 'Communion'
+  - 'Hope'
+  - 'Second Coming'
+  - 'Covenant'
+---
+
+> For as often as ye eat this bread, and drink this cup, ye do shew the Lord's death till he come. — 1 Corinthians 11:26 (KJV)
+
+Communion is usually treated like a rearview mirror. You take the bread, you take the cup, you remember a Friday afternoon in Jerusalem two thousand years ago. That is not wrong. But Paul slips a phrase into the middle of his instruction that almost no one stops on: *till he come.*
+
+The table looks two directions at once.
+
+## What You Are Saying When You Take It
+
+Behind you is the cross. Ahead of you is the second coming. The bread between your fingers connects the two ends of the same covenant. Every time you take it, you are declaring a sentence with two halves. The first half: He died for you. The second half: He is coming back.
+
+Most of us are good at remembering the cross. We were taught how. We can quote the verse, picture the scene, feel the weight. The harder half is living as if the second clause is just as real. He has not finished. The story is not over. The empty chair at the table is waiting on a guest who keeps His promises.
+
+## Memory That Builds Hope
+
+Hope without memory drifts. Memory without hope deadens. The communion table is built to hold both. You remember what He has already done so that you can endure what He has not yet finished.
+
+That changes how you sit at the table. The cup in your hand is a receipt for a price already paid. The bread is also a deposit on a feast still to come. You are not stuck between two events. You are held inside one continuous covenant, with a beginning you can trust and an ending you can wait for.
+
+When was the last time you took communion and felt the full reach of it, both ways at once? The cross at your back, His return on the horizon, you in between, remembering and waiting?


### PR DESCRIPTION
## Daily Devotion — 2026-05-08

**Source:** Lesson 10 — When He Chose the Table Over Everything (Friday entry)

> Communion is usually treated like a rearview mirror. Paul slips a phrase into the middle of his instruction that almost no one stops on: till he come.

---
Once merged, the devotion-broadcast workflow will automatically send this to The Daily Word subscribers via ConvertKit.
