### PR TITLE
[codex] Fix brace-expansion Dependabot alert

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     },
     "overrides": {
       "@isaacs/brace-expansion@<=5.0.0": ">=5.0.1",
-      "brace-expansion": "5.0.5",
+      "brace-expansion": "5.0.6",
       "glob@>=10.2.0 <10.5.0": ">=10.5.0",
       "js-yaml@<3.14.2": ">=3.14.2",
       "js-yaml@>=4.0.0 <4.1.1": ">=4.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 overrides:
   '@isaacs/brace-expansion@<=5.0.0': '>=5.0.1'
-  brace-expansion: 5.0.5
+  brace-expansion: 5.0.6
   glob@>=10.2.0 <10.5.0: '>=10.5.0'
   js-yaml@<3.14.2: '>=3.14.2'
   js-yaml@>=4.0.0 <4.1.1: '>=4.1.1'
@@ -2079,8 +2079,8 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
-  brace-expansion@5.0.5:
-    resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
+  brace-expansion@5.0.6:
+    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
     engines: {node: 18 || 20 || >=22}
 
   braces@3.0.3:
@@ -7015,7 +7015,7 @@ snapshots:
 
   baseline-browser-mapping@2.10.29: {}
 
-  brace-expansion@5.0.5:
+  brace-expansion@5.0.6:
     dependencies:
       balanced-match: 4.0.4
 
@@ -9420,19 +9420,19 @@ snapshots:
 
   minimatch@10.2.3:
     dependencies:
-      brace-expansion: 5.0.5
+      brace-expansion: 5.0.6
 
   minimatch@10.2.4:
     dependencies:
-      brace-expansion: 5.0.5
+      brace-expansion: 5.0.6
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.5
+      brace-expansion: 5.0.6
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 5.0.5
+      brace-expansion: 5.0.6
 
   minimist@1.2.8: {}
 


### PR DESCRIPTION
## Summary
- Updates the `brace-expansion` pnpm override from `5.0.5` to patched `5.0.6` for GHSA-jxxr-4gwj-5jf2 / CVE-2026-45149.
- Regenerates `pnpm-lock.yaml` so all `minimatch` paths resolve `brace-expansion@5.0.6`.

## Validation
- `pnpm install --lockfile-only`
- `pnpm install --frozen-lockfile`
- `pnpm why brace-expansion`
- `pnpm check`
- `pnpm audit --prod`
- `git diff --check`