### PR TITLE
Devotion: He Chose the Women First

### DIFF
--- a/src/posts/2026-05-26-he-chose-the-women-first.mdx
+++ b/src/posts/2026-05-26-he-chose-the-women-first.mdx
@@ -1,0 +1,32 @@
+---
+title: 'He Chose the Women First'
+date: '2026-05-26'
+excerpt: 'Two witnesses were required by Jewish law, and they had to be men. On the first morning of the new creation, Jesus picked two women.'
+category: 'Daily Word'
+series: 'He Is Risen - The Victory That Changes Everything'
+tags:
+  - 'Matthew 28'
+  - 'Resurrection'
+  - 'Witness'
+  - 'Authority'
+---
+
+> And as they went to tell his disciples, behold, Jesus met them, saying, All hail. And they came and held him by the feet, and worshipped him. -- Matthew 28:9 (KJV)
+
+In the courts of His day, the testimony of a woman did not count. Two witnesses were required, and they had to be men. That was the rule everyone agreed to. Jesus broke it on the first morning of the new creation.
+
+He met the two Marys on the road as they ran to tell the disciples. Not in the temple. Not in front of the rulers. On a road, in the early hours, with two women whose word would not stand up in any tribunal in Jerusalem. He greeted them, *All hail*, and they fell at His feet and worshipped Him.
+
+## The Truth-Tellers He Chose
+
+The chief priests were already buying lies that morning. The guards were taking silver to say the disciples stole the body. Power was being used to bend the story toward something safer than resurrection. Meanwhile, two women without status were running through dawn light with the only true account of what happened.
+
+Jesus did not validate their witness because women had earned the standing. He validated it because they saw what they saw, and they told it. That is what He honors. Eyes that watched, lips that spoke, feet that ran toward the disciples instead of away from the threat.
+
+## What Their Witness Costs
+
+The world will pay for a comfortable story. It will pay for silence, for spin, for testimony that protects the powerful. It costs something to be a truth-teller with no platform. The Marys were going to be doubted. They knew it. They went anyway.
+
+If you have been carrying a truth that nobody is rewarding, take heart in what happened that morning. The risen Jesus does not measure a witness by the platform that carries it. He meets the truthful in low places. He says *All hail* to the ones the powerful would dismiss.
+
+Who is running through the dawn in your life with a true thing nobody wants to hear? Listen. The road still belongs to them.


### PR DESCRIPTION
## Daily Devotion -- 2026-05-26

**Source:** Lesson 13 -- He Is Risen — The Victory That Changes Everything (Tuesday entry)

> Two witnesses were required by Jewish law, and they had to be men. On the first morning of the new creation, Jesus picked two women.

---
This source PR stores the authoring copy in personal-site. Publication and Kit draft creation happen from the synced The Morning Portion PR.
