### PR TITLE
chore(subscribe): rebrand newsletter to blog updates

### DIFF
--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -12,7 +12,7 @@ import { POST_CATEGORIES } from '@/utils/post-taxonomy';
 
 export const metadata: Metadata = {
   title: 'Articles & Reflections',
-  description: 'Daily Word posts, biblical reflections, and essays.',
+  description: 'Essays, field notes, and biblical reflections.',
   alternates: {
     canonical: '/blog',
   },
@@ -65,10 +65,10 @@ export default function BlogIndex() {
               Browse the library
             </a>
             <a
-              href="#daily-word"
+              href="#subscribe"
               className="a11y-focus-ring rounded-full border border-(--accent-border) px-5 py-2.5 text-sm font-medium text-(--text-primary) transition hover:border-(--accent) hover:bg-(--accent-transparent)"
             >
-              Subscribe to The Daily Word
+              Subscribe for updates
             </a>
           </div>
         </div>
@@ -171,12 +171,11 @@ export default function BlogIndex() {
         </Section>
       </div>
 
-      <div id="daily-word">
-        <Section title="The Daily Word" emoji="✉️">
+      <div id="subscribe">
+        <Section title="Subscribe" emoji="✉️">
           <p className="text-sm leading-relaxed text-(--text-secondary)">
-            Subscribe to The Daily Word for free weekday scripture reflections, delivered to your
-            inbox every weekday morning. Short, KJV-rooted reflections rooted in the Sunday School
-            lesson series.
+            New essays, field notes, and writing — straight to your inbox. No spam, unsubscribe
+            anytime.
           </p>
           <SubscribeForm />
         </Section>

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -174,8 +174,7 @@ export default function BlogIndex() {
       <div id="subscribe">
         <Section title="Subscribe" emoji="✉️">
           <p className="text-sm leading-relaxed text-(--text-secondary)">
-            New essays, field notes, and writing — straight to your inbox. No spam, unsubscribe
-            anytime.
+            New essays, field notes, and writing — straight to your inbox.
           </p>
           <SubscribeForm />
         </Section>

--- a/src/app/daily-word/page.tsx
+++ b/src/app/daily-word/page.tsx
@@ -2,21 +2,18 @@ import type { Metadata } from 'next';
 import Link from 'next/link';
 
 import PageLayout from '@/components/PageLayout';
-import SubscribeForm from '@/components/SubscribeForm';
 import { formatPostDate } from '@/utils/helpers';
 import { getAllPostsMeta } from '@/utils/posts';
 
 export const metadata: Metadata = {
   title: 'The Daily Word',
-  description:
-    "Free weekday scripture reflections and notes from Brandon's Sunday School series. Subscribe to get each post by email.",
+  description: "Archive of weekday scripture reflections from Brandon's Sunday School series.",
   alternates: {
     canonical: '/daily-word',
   },
   openGraph: {
     title: 'The Daily Word',
-    description:
-      "Free weekday scripture reflections and notes from Brandon's Sunday School series. Subscribe to get each post by email.",
+    description: "Archive of weekday scripture reflections from Brandon's Sunday School series.",
     url: '/daily-word',
   },
 };
@@ -28,16 +25,15 @@ export default function DailyWordPage() {
 
   return (
     <PageLayout title="The Daily Word" backHref="/" backLabel="Back to Home">
-      {/* Hero + Subscribe */}
+      {/* Hero */}
       <section className="rounded-4xl border border-(--accent-border) bg-white/3 p-6 sm:p-8">
-        <p className="text-sm uppercase tracking-[0.22em] text-(--accent)">Free Weekday Email</p>
+        <p className="text-sm uppercase tracking-[0.22em] text-(--accent)">Archive</p>
         <h2 className="mt-4 max-w-2xl text-3xl font-semibold leading-tight text-(--text-primary) sm:text-4xl">
           The Daily Word
         </h2>
         <p className="mt-4 max-w-2xl text-base leading-relaxed text-(--text-secondary)">
-          The Daily Word is a free, weekday scripture reflection delivered straight to your inbox.
-          Each post is a 2-minute read rooted in the Sunday School lesson series — designed to start
-          your day in the Word.
+          A weekday scripture reflection series rooted in the Sunday School lessons. Each post is a
+          2-minute read.
         </p>
 
         {currentSeries && (
@@ -47,10 +43,6 @@ export default function DailyWordPage() {
             </span>
           </div>
         )}
-
-        <div className="mt-6 max-w-md">
-          <SubscribeForm />
-        </div>
       </section>
 
       {/* Post list */}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -163,8 +163,7 @@ export default async function Home() {
           />
           <Section title="Subscribe to Saucy.tech Updates" emoji="✉️">
             <p className="text-sm leading-relaxed text-(--text-secondary)">
-              New essays, field notes, and writing — straight to your inbox. No spam, unsubscribe
-              anytime.
+              New essays, field notes, and writing — straight to your inbox.
             </p>
             <SubscribeForm />
           </Section>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -161,11 +161,10 @@ export default async function Home() {
             eyebrow="Faith"
             meta="Truth Chapel livestreams and teaching"
           />
-          <Section title="Subscribe to The Daily Word" emoji="✉️">
+          <Section title="Subscribe to Saucy.tech Updates" emoji="✉️">
             <p className="text-sm leading-relaxed text-(--text-secondary)">
-              The Daily Word delivers a short scripture reflection to your inbox every weekday
-              morning. Rooted in weekly Sunday School lessons, each post is a 2-minute read designed
-              to start your day in the Word. Free, always.
+              New essays, field notes, and writing — straight to your inbox. No spam, unsubscribe
+              anytime.
             </p>
             <SubscribeForm />
           </Section>

--- a/src/app/rss.xml/route.ts
+++ b/src/app/rss.xml/route.ts
@@ -34,7 +34,7 @@ export async function GET() {
   <channel>
     <title>${SITE_NAME} — Writing</title>
     <link>${absoluteUrl('/')}</link>
-    <description>Articles, reflections, and The Daily Word.</description>
+    <description>Essays, field notes, and biblical reflections.</description>
     <language>en-us</language>
     <lastBuildDate>${lastBuildDate}</lastBuildDate>
     <atom:link href="${selfUrl}" rel="self" type="application/rss+xml" />

--- a/src/components/SubscribeCard.tsx
+++ b/src/components/SubscribeCard.tsx
@@ -38,23 +38,21 @@ export default function SubscribeCard({
   const defaultsByContext = {
     default: {
       eyebrow: 'Newsletter',
-      title: 'The Daily Word',
-      modalTitle: 'The Daily Word',
+      title: 'Saucy.tech Updates',
+      modalTitle: 'Saucy.tech Updates',
       meta: undefined,
-      description:
-        'Weekday scripture reflections, the occasional weekend note, and future article updates. Free.',
+      description: 'New essays, field notes, and writing — straight to your inbox.',
     },
     post: {
       eyebrow: 'Keep Reading',
       title: 'Enjoyed this post?',
-      modalTitle: 'Subscribe — The Daily Word',
-      meta: 'Get the next reflection in your inbox.',
-      description:
-        'Weekday scripture reflections, the occasional weekend note, and future article updates. Free.',
+      modalTitle: 'Subscribe — Saucy.tech Updates',
+      meta: 'Get new posts in your inbox.',
+      description: 'New essays, field notes, and writing — straight to your inbox.',
     },
     'tag-archive': {
       eyebrow: 'Tag Updates',
-      title: contextLabel ? `More on ${contextLabel}` : 'More tagged reflections',
+      title: contextLabel ? `More on ${contextLabel}` : 'More tagged posts',
       modalTitle: contextLabel ? `Subscribe: ${contextLabel} updates` : 'Subscribe for tag updates',
       meta:
         normalizedCount !== undefined
@@ -73,8 +71,8 @@ export default function SubscribeCard({
           ? `${normalizedCount} post${normalizedCount === 1 ? '' : 's'} in this category.`
           : undefined,
       description: contextLabel
-        ? `Subscribe for future ${contextLabel.toLowerCase()} posts, plus the occasional weekend note.`
-        : 'Subscribe for future posts in this category, plus the occasional weekend note.',
+        ? `Subscribe for future ${contextLabel.toLowerCase()} posts.`
+        : 'Subscribe for future posts in this category.',
     },
   } as const;
 

--- a/src/components/layout/SiteNav.tsx
+++ b/src/components/layout/SiteNav.tsx
@@ -37,12 +37,14 @@ export default function SiteNav({
       >
         {items.map((item) => {
           const active = isNavActive(pathname, item, items);
+          const isExternal = /^https?:\/\//.test(item.href);
           return (
             <li key={`${item.href}-${item.label}`}>
               <Link
                 href={item.href}
                 className={cn(linkClass, active && activeClass)}
                 aria-current={active ? 'page' : undefined}
+                {...(isExternal ? { target: '_blank', rel: 'noopener noreferrer' } : {})}
               >
                 {item.label}
               </Link>

--- a/src/config/site-nav.ts
+++ b/src/config/site-nav.ts
@@ -32,7 +32,7 @@ export function getSiteNavItems({ latestSlug }: { latestSlug: string | null }): 
     { href: '/portfolio', label: 'Portfolio', match: 'exact' },
     { href: '/field-notes', label: 'Field notes', match: 'exact' },
     { href: '/bitcoin', label: 'Bitcoin', match: 'exact' },
-    { href: '/daily-word', label: 'Daily Word', match: 'exact' },
+    { href: 'https://morningportion.com', label: 'Morning Portion', match: 'exact' },
     { href: '/support', label: 'Support', match: 'exact' }
   );
   return items;

--- a/src/data/projects.ts
+++ b/src/data/projects.ts
@@ -66,7 +66,7 @@ export const projects: Project[] = [
       'A weekday scripture reflection series — a 2-minute read each morning, rooted in Sunday School lessons. Currently published as a section of this site; subscribe for the daily email.',
     links: [
       { href: '/daily-word', label: 'Read on site' },
-      { href: '/daily-word#subscribe', label: 'Subscribe' },
+      { href: '/blog#subscribe', label: 'Subscribe' },
     ],
   },
   {

--- a/src/data/projects.ts
+++ b/src/data/projects.ts
@@ -3,7 +3,7 @@
  * Edit here to update copy. Bump `projectsLastUpdated` when you revise.
  */
 
-export const projectsLastUpdated = '2026-05-21';
+export const projectsLastUpdated = '2026-05-22';
 
 export type ProjectGroup = 'apps' | 'tools' | 'open-source';
 
@@ -61,12 +61,12 @@ export const projects: Project[] = [
     group: 'apps',
     title: 'The Daily Word',
     status: 'launched',
-    tags: ['Devotion', 'MDX', 'Email'],
+    tags: ['Devotion', 'MDX', 'Archive'],
     blurb:
-      'A weekday scripture reflection series — a 2-minute read each morning, rooted in Sunday School lessons. Currently published as a section of this site; subscribe for the daily email.',
+      'A weekday scripture reflection series — a 2-minute read each morning, rooted in Sunday School lessons. The on-site archive runs through May 2026; new entries now publish at The Morning Portion.',
     links: [
-      { href: '/daily-word', label: 'Read on site' },
-      { href: '/blog#subscribe', label: 'Subscribe' },
+      { href: '/daily-word', label: 'Browse Archive' },
+      { href: 'https://morningportion.com', label: 'Read New Entries' },
     ],
   },
   {


### PR DESCRIPTION
## Summary

- The Daily Word devotion series has migrated to morningportion.com with its own Kit list. This rebrands the personal-site subscribe surfaces to be generic blog-newsletter copy.
- Subscribe form continues to read `CONVERTKIT_FORM_ID` — value to be swapped in Vercel env to the new blog Kit form ID after merge.
- Removes the misleading embedded subscribe form + "Free Weekday Email" hero copy from `/daily-word` (archive route stays; PR 2 will add a "continued at The Morning Portion" pointer).

## Changes

- `src/components/SubscribeCard.tsx` — default/post/tag-archive/category-archive defaults rebranded to "Saucy.tech Updates" with blog-generic descriptions.
- `src/app/page.tsx` — homepage subscribe section title + body rewritten.
- `src/app/blog/page.tsx` — meta description, hero CTA, in-page anchor (`#daily-word` → `#subscribe`), and bottom subscribe section all rewritten.
- `src/app/rss.xml/route.ts` — feed `<description>` no longer references "The Daily Word".
- `src/app/daily-word/page.tsx` — hero rewritten as archive; embedded `SubscribeForm` removed.

## Operational follow-up (not in this PR)

After merge: in Vercel project env, update `CONVERTKIT_FORM_ID` to the new blog Kit form ID. Old Daily Word form ID becomes orphaned on this site (still in use over at the-morning-portion).

## Test plan

- [x] `pnpm quality:gate` passes locally (warnings are pre-existing in unrelated post files).
- [ ] CI green.
- [ ] After deploy: visit `/`, `/blog`, `/blog/[slug]`, `/blog/category/daily-word`, `/blog/tag/[any]`, `/daily-word` — confirm rebranded copy renders and modal/inline subscribe form still submits successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)