### PR TITLE
chore(daily-word): point readers to morningportion.com

### DIFF
--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -138,12 +138,22 @@ export default function BlogIndex() {
               {category.description}
             </p>
             <div className="mt-5 flex flex-col gap-2">
+              {category.key === 'daily-word' && (
+                <a
+                  href="https://morningportion.com"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="a11y-focus-ring inline-flex rounded-xs text-sm font-medium text-(--accent) transition hover:text-(--text-primary)"
+                >
+                  Read new entries at morningportion.com →
+                </a>
+              )}
               {category.href && (
                 <Link
                   href={category.href}
                   className="a11y-focus-ring inline-flex rounded-xs text-sm font-medium text-(--accent) transition hover:text-(--text-primary)"
                 >
-                  Visit the Daily Word →
+                  Browse the archive →
                 </Link>
               )}
               {category.latest && (

--- a/src/app/daily-word/page.tsx
+++ b/src/app/daily-word/page.tsx
@@ -33,13 +33,25 @@ export default function DailyWordPage() {
         </h2>
         <p className="mt-4 max-w-2xl text-base leading-relaxed text-(--text-secondary)">
           A weekday scripture reflection series rooted in the Sunday School lessons. Each post is a
-          2-minute read.
+          2-minute read. This archive runs through May 2026. New entries now publish at The
+          Morning Portion.
         </p>
+
+        <div className="mt-6 flex flex-wrap gap-3">
+          <a
+            href="https://morningportion.com"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="a11y-focus-ring rounded-full bg-(--accent) px-5 py-2.5 text-sm font-medium text-(--on-accent) transition hover:brightness-110"
+          >
+            Read new entries at morningportion.com →
+          </a>
+        </div>
 
         {currentSeries && (
           <div className="mt-5">
             <span className="inline-block rounded-2xl border border-(--accent-border) bg-(--accent-transparent) px-4 py-1.5 text-xs uppercase tracking-[0.18em] text-(--accent)">
-              Current Series: {currentSeries}
+              Final Series on Archive: {currentSeries}
             </span>
           </div>
         )}


### PR DESCRIPTION
## Summary
- Mark `/daily-word` landing page as archive; add prominent CTA + hero copy directing readers to morningportion.com (the new home for new entries).
- Update Daily Word category card on `/blog` to surface an external morningportion.com link above the archive link.
- No content changes to `src/posts/` (archive intact).

## Why
Daily Word authoring moved to the `the-morning-portion` repo, publishing to morningportion.com. This repo's archive still exists for SEO and deep-link continuity, but visitors should be routed to the live site for new content.

## Test plan
- [x] Visit `/daily-word` locally: hero copy mentions the archive cutoff (May 2026); morningportion.com CTA renders as accent button and opens in new tab with `rel=noopener noreferrer`.
- [x] Visit `/blog`: Daily Word category card shows external "Read new entries at morningportion.com" link first, then "Browse the archive", then latest archive post.
- [x] Confirm no `devotion` label on PR (would trigger Kit broadcast workflow).
- [x] `pnpm quality:gate` passes (verified locally; pre-existing archive warnings unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)