### PR TITLE
[codex] Skip empty field notes sections

### DIFF
--- a/src/app/field-notes/page.tsx
+++ b/src/app/field-notes/page.tsx
@@ -46,6 +46,7 @@ export const metadata: Metadata = {
 
 export default function FieldNotesPage() {
   const lastUpdatedLabel = formatPostDate(fieldNotesLastUpdated);
+  const sections = fieldNotesSections.filter((section) => section.items.length > 0);
 
   return (
     <PageLayout title="Field notes" backHref="/" backLabel="Back to Home">
@@ -56,7 +57,7 @@ export default function FieldNotesPage() {
         </p>
         <p className="text-sm text-(--text-secondary)">
           <span className="uppercase tracking-[0.14em] text-xs">
-            {fieldNotesSections.map((section, i) => (
+            {sections.map((section, i) => (
               <span key={section.id}>
                 {i > 0 && <span className="text-(--accent-border)"> · </span>}
                 <a
@@ -74,7 +75,7 @@ export default function FieldNotesPage() {
       </div>
 
       <div className="mt-10 max-w-3xl space-y-12">
-        {fieldNotesSections.map((section) => (
+        {sections.map((section) => (
           <section key={section.id} id={section.id} className="scroll-mt-24">
             <header className="border-t border-(--accent-border) pt-5">
               <h2 className="text-lg font-semibold leading-tight text-(--text-primary)">


### PR DESCRIPTION
## Summary

- Filters field note sections to sections with at least one item before rendering the jump links and section bodies.
- Prevents the new empty `paused` section from displaying after `c290945e96ce7e0bfbfb707bb6f2ac8fdcb5bd5b` moved its last item into another section.

## Impact

The `/field-notes` page no longer shows an empty section heading when a configured section has no items. This keeps the renderer resilient to future data-only taxonomy changes.

## Validation

- `pnpm lint`
- `pnpm exec tsc --noEmit`
- `pnpm test --runInBand`