### PR TITLE
docs: sync architecture and security notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ This repo uses pnpm pinned via Corepack (see package.json "packageManager").
 ```
 personal-site/
 ├── .github/workflows/         # CI, devotion broadcast, lighthouse
-├── docs/                      # Architecture map, runbooks, upgrade matrices
+├── docs/                      # Runbooks and generated architecture docs
 ├── public/                    # Static assets
 │   └── images/blog/           # Blog post images
 ├── scripts/                   # Content validators, broadcast, doc gen
@@ -35,8 +35,6 @@ personal-site/
 │   ├── utils/                 # posts.ts, security.ts, constants.ts
 │   └── proxy.ts               # CSP/security headers (Next.js file convention)
 ├── tests/                     # Playwright E2E specs
-├── AGENTS.md                  # Codebase facts (canonical agent doc)
-├── CLAUDE.md                  # Claude-specific guide (writing rules, gotchas)
 ├── next.config.js
 ├── package.json
 └── README.md
@@ -109,9 +107,8 @@ Daily Word devotions are the primary content pipeline. The lifecycle:
    `KIT_API_KEY`.
 4. Vercel deploys the post to production.
 
-Writing rules, frontmatter schema, and agent gotchas live in
-[CLAUDE.md](./CLAUDE.md). Codebase architecture, security, and full env var
-reference live in [AGENTS.md](./AGENTS.md).
+Writing rules and quality checks for published content live in the scripts and
+runbooks in [`docs/`](./docs).
 
 `pnpm broadcast` is retained as a **manual fallback only** and is not the
 primary publishing path.
@@ -141,6 +138,9 @@ LNURL_METADATA_DESC="Lightning tip jar for brandon"
 # Next.js App URL (for OpenGraph)
 NEXT_PUBLIC_APP_URL=https://your-domain.com
 
+# Optional canonical site URL override for metadata and absolute URLs
+SITE_URL=https://your-domain.com
+
 # ConvertKit API configuration for email subscriptions (optional)
 CONVERTKIT_API_KEY=
 CONVERTKIT_FORM_ID=
@@ -148,6 +148,17 @@ CONVERTKIT_FORM_ID=
 # ConvertKit v4 API — optional manual fallback for `pnpm broadcast`
 CK_SECRET_KEY=        # Settings → Advanced → API Secret
 CK_PUBLISHER_ID=      # numeric account ID from Settings → Advanced
+
+# Optional distributed rate limiting
+UPSTASH_REDIS_REST_URL=
+UPSTASH_REDIS_REST_TOKEN=
+
+# Optional CSP/reporting toggles
+ENABLE_CSP_VIOLATION_REPORTS=0
+CSP_REPORT_ONLY=0
+
+# Optional error monitoring
+SENTRY_DSN=
 ```
 
 ### GitHub Actions Secrets
@@ -224,7 +235,7 @@ This check:
 - fails when a local image reference is missing in `public/`
 - warns on large images and fails for oversized images
 
-Run `pnpm docs:architecture` to regenerate `docs/architecture-map.md` after adding routes, API endpoints, or major utility/component files.
+Run `pnpm docs:architecture` to regenerate the local `docs/architecture-map.md` report after adding routes, API endpoints, or major utility/component files. That report is gitignored.
 
 Run `pnpm quality:gate` as the local "definition of done" check before pushing. It runs:
 - `pnpm lint`
@@ -236,12 +247,10 @@ Run `pnpm quality:gate` as the local "definition of done" check before pushing. 
 
 CI now uses this same `quality:gate` command before build and E2E smoke checks.
 
-For framework/runtime modernization work, use the upgrade contract matrix:
-- `docs/testing/framework-upgrade-test-matrix.md`
-
 Operational runbooks:
 - `docs/runbooks/api-incident-response.md`
 - `docs/runbooks/content-guardrails.md`
+- `docs/security-performance-observability.md`
 
 ## Deployment
 

--- a/docs/runbooks/api-incident-response.md
+++ b/docs/runbooks/api-incident-response.md
@@ -5,6 +5,8 @@
 - `/api/invoice`
 - `/api/btcusd`
 - `/api/lnurlp/brandon/callback`
+- `/api/csp-report`
+- `/api/webmention`
 
 ## Fast Triage (first 10 minutes)
 - Confirm deploy status and recent changes in Vercel.
@@ -24,6 +26,9 @@
   - `coingecko_timeout`
   - `coingecko_request_failed`
   - `btcusd_unhandled_error`
+- Reporting endpoints:
+  - `csp_violation_report`
+  - `webmention_received`
 
 ## Endpoint-Specific Playbooks
 
@@ -41,6 +46,14 @@
 - Validate `NOSTR_WALLET_CONNECT_URL` presence and freshness.
 - Confirm payment hash lookups still return parseable responses.
 - Watch for suspicious-request and invalid-input spikes (abuse vs. product issue).
+
+### `/api/csp-report`
+- Traffic should be low and only present when `ENABLE_CSP_VIOLATION_REPORTS=1`.
+- Confirm payloads are truncated and the route returns `204`.
+
+### `/api/webmention`
+- Expected responses are `202` for accepted requests, `400` for off-site or incomplete payloads, and `415` for unsupported content types.
+- Treat spikes as either abuse/noise or an intentional integration attempt; this route currently logs and accepts but does not persist mentions.
 
 ## Mitigation Checklist
 - Reduce blast radius: feature-flag or temporary fallback response if needed.

--- a/docs/security-performance-observability.md
+++ b/docs/security-performance-observability.md
@@ -10,16 +10,27 @@
 ## Verification checklist
 
 - Run `pnpm lint`, `pnpm test`, and `pnpm build` before release.
-- Run guardrails: `pnpm content:validate`, `pnpm content:check-links`, `pnpm content:check-images`.
+- Run guardrails: `pnpm content:validate`, `pnpm content:check-links`, `pnpm content:check-images`, `pnpm security:drift`.
 - Exercise all public API routes with valid and invalid payloads.
 - Validate CSP is present once and includes per-request nonce in `script-src`.
 - Validate proxy excludes static assets (`.*\\..*` matcher path).
 - Confirm `/api/btcusd` responds with `Cache-Control` and `X-Cache-Status` headers.
+- If `ENABLE_CSP_VIOLATION_REPORTS=1`, confirm `/api/csp-report` returns `204` and logs `csp_violation_report`.
+- Confirm `/api/webmention` accepts only on-site `target` URLs and logs `webmention_received`.
+
+## Security/runtime toggles
+
+- `SITE_URL` overrides `NEXT_PUBLIC_APP_URL` for canonical metadata and absolute URLs.
+- `UPSTASH_REDIS_REST_URL` and `UPSTASH_REDIS_REST_TOKEN` enable distributed rate limiting; without them the app falls back to in-memory buckets per instance.
+- `ENABLE_CSP_VIOLATION_REPORTS=1` adds `report-uri` pointing at `/api/csp-report`.
+- `CSP_REPORT_ONLY=1` duplicates the active CSP into `Content-Security-Policy-Report-Only`.
+- `SENTRY_DSN` enables Sentry initialization in `src/instrumentation.ts`.
 
 ## Structured events
 
 Primary API observability events:
 - Subscribe: `convertkit_error_response`, `convertkit_timeout`, `convertkit_request_failed`, `subscribe_unhandled_error`
 - BTC/USD: `coingecko_error_response`, `coingecko_invalid_payload`, `coingecko_timeout`, `coingecko_request_failed`, `btcusd_unhandled_error`
+- Webmention/CSP: `webmention_received`, `csp_violation_report`
 
 See `docs/runbooks/api-incident-response.md` for triage flow.


### PR DESCRIPTION
## Summary
- remove stale README references to missing local docs and clarify that the architecture map is generated locally and gitignored
- document the current security and runtime toggles that are implemented in code, including SITE_URL, Upstash rate limiting, CSP reporting, and Sentry
- align the security and incident runbooks with the current API surface, including /api/csp-report, /api/webmention, and their structured events

## Test Plan
- pnpm docs:architecture
- pnpm quality:gate
- pnpm build

## Notes
- quality gate passed with existing non-blocking content-quality, orphan-link, and large-image warnings unrelated to this change