### PR TITLE
feat: position Saucy.Tech as Brandon + Saucy Tech LLC

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,0 +1,82 @@
+import { Metadata } from 'next';
+
+import PageLayout from '@/components/PageLayout';
+import { about, aboutLastUpdated } from '@/data/about';
+import { SITE_NAME } from '@/utils/constants';
+
+export const metadata: Metadata = {
+  title: 'About',
+  description:
+    'Brandon Sauceda runs Saucy Tech, building his own software products and taking on select client work.',
+  alternates: {
+    canonical: '/about',
+  },
+  openGraph: {
+    title: 'About',
+    description:
+      'Brandon Sauceda runs Saucy Tech, building his own software products and taking on select client work.',
+    url: '/about',
+    type: 'profile',
+    images: [
+      {
+        url: '/headshot.jpeg',
+        width: 1024,
+        height: 1024,
+        alt: `${SITE_NAME} - About`,
+      },
+    ],
+  },
+};
+
+export default function About() {
+  return (
+    <PageLayout title="About">
+      <section>
+        <p className="text-base leading-relaxed text-(--text-secondary)">{about.lead}</p>
+      </section>
+
+      <section className="space-y-4">
+        <h2 className="text-2xl font-semibold">What Saucy Tech does</h2>
+        <p className="text-base leading-relaxed text-(--text-secondary)">{about.shopOneLiner}</p>
+      </section>
+
+      <section className="space-y-4">
+        <h2 className="text-2xl font-semibold">Products</h2>
+        <div className="flex flex-col gap-4">
+          {about.products.map((product) => {
+            const isExternal = /^https?:\/\//.test(product.href);
+            return (
+              <a
+                key={product.name}
+                href={product.href}
+                {...(isExternal ? { target: '_blank', rel: 'noopener noreferrer' } : {})}
+                className="block rounded-lg border border-(--accent-border) bg-white/10 p-5 transition hover:bg-white/15"
+              >
+                <h3 className="mb-1 text-lg font-semibold">{product.name}</h3>
+                <p className="text-sm text-(--text-secondary)">{product.oneLiner}</p>
+              </a>
+            );
+          })}
+        </div>
+      </section>
+
+      <section className="space-y-4">
+        <h2 className="text-2xl font-semibold">Track record</h2>
+        <p className="text-base leading-relaxed text-(--text-secondary)">{about.trackRecord}</p>
+      </section>
+
+      <section id="work-with-me" className="scroll-mt-24 space-y-4">
+        <h2 className="text-2xl font-semibold">{about.workWithMe.heading}</h2>
+        <p className="text-base leading-relaxed text-(--text-secondary)">{about.workWithMe.body}</p>
+        <a
+          href={`mailto:${about.workWithMe.email}`}
+          className="inline-block rounded-sm bg-(--accent) px-4 py-2 text-(--on-accent) transition hover:bg-(--accent-dark)"
+        >
+          {about.workWithMe.email}
+        </a>
+      </section>
+
+      <p className="text-xs text-(--text-secondary)">About updated {aboutLastUpdated}</p>
+    </PageLayout>
+  );
+}

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -7,14 +7,14 @@ import { SITE_NAME } from '@/utils/constants';
 export const metadata: Metadata = {
   title: 'About',
   description:
-    'Brandon Sauceda runs Saucy Tech, building his own software products and taking on select client work.',
+    'Brandon Sauceda is an independent developer building his own software products, plus a few client projects a year.',
   alternates: {
     canonical: '/about',
   },
   openGraph: {
     title: 'About',
     description:
-      'Brandon Sauceda runs Saucy Tech, building his own software products and taking on select client work.',
+      'Brandon Sauceda is an independent developer building his own software products, plus a few client projects a year.',
     url: '/about',
     type: 'profile',
     images: [

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,7 +6,6 @@ import Header from '@/components/layout/Header';
 import Footer from '@/components/layout/Footer';
 import { getFooterNavItems, getSiteNavItems } from '@/config/site-nav';
 import { SITE_NAME, SITE_DESCRIPTION_HIRING, SITE_URL } from '@/utils/constants';
-import { getAllPostsMeta } from '@/utils/posts';
 import { APPEARANCE_STORAGE_KEY, THEME_STORAGE_KEY } from '@/utils/theme';
 import ClientGalaxyBackground from '@/components/ClientGalaxyBackground';
 import { Analytics } from '@vercel/analytics/next';
@@ -97,9 +96,8 @@ export const metadata: Metadata = {
 
 export default async function RootLayout({ children }: { children: React.ReactNode }) {
   const nonce = (await headers()).get('x-nonce') ?? undefined;
-  const latestSlug = getAllPostsMeta()[0]?.slug ?? null;
-  const navItems = getSiteNavItems({ latestSlug });
-  const footerNavItems = getFooterNavItems({ latestSlug });
+  const navItems = getSiteNavItems();
+  const footerNavItems = getFooterNavItems();
   return (
     <html lang="en" suppressHydrationWarning>
       <head>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -106,7 +106,13 @@ export default async function Home() {
         dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
       />
       <div className="space-y-6 w-full max-w-lg mx-auto">
-        <Profile {...profileData} />
+        <div className="space-y-2">
+          <Profile {...profileData} />
+          <p className="text-center text-sm leading-relaxed text-(--text-secondary)">
+            Saucy Tech is my one-person company: I build my own software products and take on select
+            client work.
+          </p>
+        </div>
         <SocialBar socials={socialLinks} />
 
         <div className="space-y-3">
@@ -139,11 +145,19 @@ export default async function Home() {
           />
           <LinkCard
             key="my-projects"
-            title="Portfolio"
+            title="Projects"
             href="/portfolio"
             icon={<span className="text-2xl">🚀</span>}
-            eyebrow="Portfolio"
-            meta="Gov-tech, projects, awards, résumé PDF"
+            eyebrow="Projects"
+            meta="Products, track record, talks, and résumé"
+          />
+          <LinkCard
+            key="work-with-me"
+            title="Work with me"
+            href="/about#work-with-me"
+            icon={<span className="text-2xl">🤝</span>}
+            eyebrow="Work with me"
+            meta="Selective product and client work"
           />
           <LinkCard
             key="bitcoin"
@@ -163,7 +177,7 @@ export default async function Home() {
           />
           <Section title="Subscribe to Saucy.tech Updates" emoji="✉️">
             <p className="text-sm leading-relaxed text-(--text-secondary)">
-              New essays, field notes, and writing — straight to your inbox.
+              New essays, field notes, and writing, straight to your inbox.
             </p>
             <SubscribeForm />
           </Section>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -109,8 +109,7 @@ export default async function Home() {
         <div className="space-y-2">
           <Profile {...profileData} />
           <p className="text-center text-sm leading-relaxed text-(--text-secondary)">
-            Saucy Tech is my one-person company: I build my own software products and take on select
-            client work.
+            Independent developer. My own products, plus a few client projects a year.
           </p>
         </div>
         <SocialBar socials={socialLinks} />
@@ -153,11 +152,11 @@ export default async function Home() {
           />
           <LinkCard
             key="work-with-me"
-            title="Work with me"
+            title="Client work"
             href="/about#work-with-me"
             icon={<span className="text-2xl">🤝</span>}
-            eyebrow="Work with me"
-            meta="Selective product and client work"
+            eyebrow="Client work"
+            meta="A few projects a year"
           />
           <LinkCard
             key="bitcoin"

--- a/src/app/portfolio/page.tsx
+++ b/src/app/portfolio/page.tsx
@@ -38,7 +38,7 @@ export const metadata: Metadata = {
   },
 };
 
-const GROUP_ORDER: ProjectGroup[] = ['apps', 'tools', 'open-source'];
+const GROUP_ORDER: ProjectGroup[] = ['apps', 'tools', 'open-source', 'track-record'];
 
 const STATUS_PILL: Record<ProjectStatus, { label: string; className: string }> = {
   launched: { label: 'Launched', className: 'bg-green-500/80 text-white' },

--- a/src/app/sitemap.test.ts
+++ b/src/app/sitemap.test.ts
@@ -15,6 +15,7 @@ describe('sitemap', () => {
     const entries = sitemap();
     const urls = entries.map((e) => e.url);
     expect(urls.some((u) => u.endsWith('/links'))).toBe(true);
+    expect(urls.some((u) => u.endsWith('/about'))).toBe(true);
     expect(urls.some((u) => u.includes('/blog/tag/'))).toBe(true);
     expect(urls.some((u) => u.includes('/blog/category/daily-word'))).toBe(true);
     expect(urls.some((u) => u.includes('/blog/archive/'))).toBe(true);

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -89,6 +89,12 @@ export default function sitemap(): MetadataRoute.Sitemap {
       priority: 0.7,
     },
     {
+      url: absoluteUrl('/about'),
+      lastModified: new Date(),
+      changeFrequency: 'monthly',
+      priority: 0.8,
+    },
+    {
       url: absoluteUrl('/bitcoin'),
       lastModified: new Date(),
       changeFrequency: 'monthly',

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -1,7 +1,7 @@
 import SiteNav from '@/components/layout/SiteNav';
 import type { SiteNavItem } from '@/config/site-nav';
 import { BaseProps } from '@/types';
-import { SITE_NAME } from '@/utils/constants';
+import { LEGAL_ENTITY } from '@/utils/constants';
 import { cn } from '@/utils/helpers';
 
 type FooterProps = BaseProps & {
@@ -38,7 +38,7 @@ export default function Footer({ className, navItems }: FooterProps) {
           </a>
         </div>
         <p className="text-(--accent) text-sm opacity-80">
-          &copy; {currentYear} {SITE_NAME}
+          &copy; {currentYear} {LEGAL_ENTITY}
         </p>
       </div>
     </footer>

--- a/src/config/site-nav.ts
+++ b/src/config/site-nav.ts
@@ -8,6 +8,7 @@ export type SiteNavItem = {
 
 /** Shown in the footer after primary nav items (RSS, utility links). */
 export const FOOTER_EXTRA_NAV: SiteNavItem[] = [
+  { href: '/bitcoin', label: 'Bitcoin', match: 'exact' },
   { href: '/links', label: 'Links', match: 'exact' },
   { href: '/rss.xml', label: 'RSS', match: 'exact' },
 ];
@@ -23,21 +24,19 @@ export function isNavActive(pathname: string, item: SiteNavItem, allItems: SiteN
   return pathname === item.href || pathname.startsWith(`${item.href}/`);
 }
 
-export function getSiteNavItems({ latestSlug }: { latestSlug: string | null }): SiteNavItem[] {
+export function getSiteNavItems(): SiteNavItem[] {
   const items: SiteNavItem[] = [{ href: '/blog', label: 'Writing', match: 'prefix' }];
-  if (latestSlug) {
-    items.push({ href: `/blog/${latestSlug}`, label: 'Latest', match: 'exact' });
-  }
   items.push(
-    { href: '/portfolio', label: 'Portfolio', match: 'exact' },
+    { href: '/portfolio', label: 'Projects', match: 'exact' },
+    { href: '/about', label: 'About', match: 'exact' },
+    { href: '/about#work-with-me', label: 'Work with me', match: 'exact' },
     { href: '/field-notes', label: 'Field notes', match: 'exact' },
-    { href: '/bitcoin', label: 'Bitcoin', match: 'exact' },
     { href: 'https://morningportion.com', label: 'Morning Portion', match: 'exact' },
     { href: '/support', label: 'Support', match: 'exact' }
   );
   return items;
 }
 
-export function getFooterNavItems({ latestSlug }: { latestSlug: string | null }): SiteNavItem[] {
-  return [...getSiteNavItems({ latestSlug }), ...FOOTER_EXTRA_NAV];
+export function getFooterNavItems(): SiteNavItem[] {
+  return [...getSiteNavItems(), ...FOOTER_EXTRA_NAV];
 }

--- a/src/config/site-nav.ts
+++ b/src/config/site-nav.ts
@@ -29,7 +29,7 @@ export function getSiteNavItems(): SiteNavItem[] {
   items.push(
     { href: '/portfolio', label: 'Projects', match: 'exact' },
     { href: '/about', label: 'About', match: 'exact' },
-    { href: '/about#work-with-me', label: 'Work with me', match: 'exact' },
+    { href: '/about#work-with-me', label: 'Client work', match: 'exact' },
     { href: '/field-notes', label: 'Field notes', match: 'exact' },
     { href: 'https://morningportion.com', label: 'Morning Portion', match: 'exact' },
     { href: '/support', label: 'Support', match: 'exact' }

--- a/src/data/about.ts
+++ b/src/data/about.ts
@@ -16,7 +16,7 @@ export const about = {
   shopOneLiner:
     'Saucy Tech is how I ship my own software and take on outside work. The products are things like The Morning Portion, a daily devotional site, plus a handful of smaller apps. The client work is a few projects a year, usually web apps and product builds.',
   trackRecord:
-    'For ten years I have built public software for the State of Georgia: web apps and GIS systems used by more than 50,000 people a month, with a few national awards along the way. That is the same care I bring to Saucy Tech work.',
+    'For ten years I have built public software for the State of Georgia: web apps and GIS systems used by more than 50,000 people a month, with a few national awards along the way.',
   products: [
     {
       name: 'The Morning Portion',
@@ -36,8 +36,8 @@ export const about = {
     },
   ] as AboutProduct[],
   workWithMe: {
-    heading: 'Work with me',
-    body: 'I take on a few client projects a year, usually web apps, product builds, or help getting something unstuck. If that sounds like what you need, send me a note and tell me what you are building.',
+    heading: 'Client work',
+    body: 'I take on a few client projects a year, usually web apps and product work. If that is a fit, email me.',
     email: 'brandon@saucy.tech',
   },
 } as const;

--- a/src/data/about.ts
+++ b/src/data/about.ts
@@ -1,0 +1,43 @@
+/**
+ * Copy for the `/about` page. Centralizes the rule-sensitive prose
+ * (no em dashes, no LLM tells). Bump `aboutLastUpdated` when revised.
+ */
+
+export const aboutLastUpdated = '2026-06-06';
+
+export interface AboutProduct {
+  name: string;
+  oneLiner: string;
+  href: string;
+}
+
+export const about = {
+  lead: "I'm Brandon, a software engineer and builder in Georgia. I care about my faith, my family, and making useful things that hold up over time.",
+  shopOneLiner:
+    'Saucy Tech is how I ship my own software and take on outside work. The products are things like The Morning Portion, a daily devotional site, plus a handful of smaller apps. The client work is a few projects a year, usually web apps and product builds.',
+  trackRecord:
+    'For ten years I have built public software for the State of Georgia: web apps and GIS systems used by more than 50,000 people a month, with a few national awards along the way. That is the same care I bring to Saucy Tech work.',
+  products: [
+    {
+      name: 'The Morning Portion',
+      oneLiner: 'A daily devotional site publishing weekday scripture reflections.',
+      href: 'https://morningportion.com',
+    },
+    {
+      name: 'Roll to Eat',
+      oneLiner:
+        'A playful dinner-decision app that rolls two d20s to pair a cuisine with a main ingredient.',
+      href: 'https://roll-to-eat.vercel.app/',
+    },
+    {
+      name: 'Lightning Tip Jar',
+      oneLiner: 'A Lightning tipping interface with Nostr Wallet Connect support.',
+      href: '/support',
+    },
+  ] as AboutProduct[],
+  workWithMe: {
+    heading: 'Work with me',
+    body: 'I take on a few client projects a year, usually web apps, product builds, or help getting something unstuck. If that sounds like what you need, send me a note and tell me what you are building.',
+    email: 'brandon@saucy.tech',
+  },
+} as const;

--- a/src/data/portfolio-about.ts
+++ b/src/data/portfolio-about.ts
@@ -9,7 +9,7 @@ export const portfolioAbout = {
   headline: 'Brandon Sauceda',
   title: 'IT Development Manager · Software Engineer',
   summary:
-    'Ten years in Georgia government technology — public-facing web apps, enterprise GIS, and full-stack delivery for 50,000+ monthly users. I also ship indie apps and contribute to open source (Next.js, TypeScript, Rust).',
+    'I run Saucy Tech, where I ship my own software products and take on select client work. For ten years I have built public technology for the State of Georgia: web apps and enterprise GIS used by more than 50,000 people a month. I also contribute to open source (Next.js, TypeScript, Rust).',
   email: 'brandon@saucy.tech',
   linkedIn: 'https://linkedin.com/in/saucytech',
   github: 'https://github.com/saucy-tech',

--- a/src/data/portfolio-about.ts
+++ b/src/data/portfolio-about.ts
@@ -9,7 +9,7 @@ export const portfolioAbout = {
   headline: 'Brandon Sauceda',
   title: 'IT Development Manager · Software Engineer',
   summary:
-    'I run Saucy Tech, where I ship my own software products and take on select client work. For ten years I have built public technology for the State of Georgia: web apps and enterprise GIS used by more than 50,000 people a month. I also contribute to open source (Next.js, TypeScript, Rust).',
+    'I run Saucy Tech, where I ship my own software products and take on a few client projects a year. For ten years I have built public technology for the State of Georgia: web apps and enterprise GIS used by more than 50,000 people a month. I also contribute to open source (Next.js, TypeScript, Rust).',
   email: 'brandon@saucy.tech',
   linkedIn: 'https://linkedin.com/in/saucytech',
   github: 'https://github.com/saucy-tech',

--- a/src/data/projects.ts
+++ b/src/data/projects.ts
@@ -1,11 +1,11 @@
 /**
- * Portfolio data (`/portfolio`) — apps, tools, OSS contributions, and talks.
+ * Portfolio data (`/portfolio`): products, tools, OSS contributions, and talks.
  * Edit here to update copy. Bump `projectsLastUpdated` when you revise.
  */
 
 export const projectsLastUpdated = '2026-05-22';
 
-export type ProjectGroup = 'apps' | 'tools' | 'open-source';
+export type ProjectGroup = 'apps' | 'tools' | 'open-source' | 'track-record';
 
 export type ProjectStatus = 'launched' | 'contributor';
 
@@ -32,30 +32,7 @@ export interface Talk {
 }
 
 export const projects: Project[] = [
-  // --- Apps ---
-  {
-    id: 'gda-public-systems',
-    group: 'apps',
-    title: 'Georgia DGA — Public Web & GIS Systems',
-    status: 'launched',
-    tags: ['Product leadership', 'GIS', 'Azure', 'C#', 'Public sector'],
-    blurb:
-      'IT Development Manager for state agency systems serving 50,000+ monthly users. Owned public-facing web roadmap, cut citizen wait times 40%, led enterprise ArcGIS program (Esri SAG award), and built cross-agency APIs for five partner organizations. Details available on request — no public repo.',
-    links: [{ href: '/Brandon_Sauceda_Resume.pdf', label: 'Résumé (PDF)' }],
-  },
-  {
-    id: 'portfolio-site',
-    group: 'apps',
-    title: 'This Portfolio Site',
-    status: 'launched',
-    tags: ['Next.js', 'React', 'Tailwind CSS', 'MDX', 'Lightning'],
-    blurb:
-      'Built with Next.js (App Router), React, and Tailwind CSS, integrating @getalby/sdk Nostr Wallet Connect for native Lightning payments. Custom MDX blog, responsive design, dark mode, subtle animations. All content and components managed locally — no external CMS.',
-    links: [
-      { href: 'https://github.com/saucy-tech/personal-site', label: 'GitHub Repo' },
-      { href: '/support#lightning-tip-jar', label: 'Try Lightning Tip Jar' },
-    ],
-  },
+  // --- Products ---
   {
     id: 'daily-word',
     group: 'apps',
@@ -95,6 +72,19 @@ export const projects: Project[] = [
       { href: '/support', label: 'Live Demo' },
     ],
   },
+  {
+    id: 'portfolio-site',
+    group: 'apps',
+    title: 'This Portfolio Site',
+    status: 'launched',
+    tags: ['Next.js', 'React', 'Tailwind CSS', 'MDX', 'Lightning'],
+    blurb:
+      'Built with Next.js (App Router), React, and Tailwind CSS, integrating @getalby/sdk Nostr Wallet Connect for native Lightning payments. Custom MDX blog, responsive design, dark mode, subtle animations. All content and components managed locally, no external CMS.',
+    links: [
+      { href: 'https://github.com/saucy-tech/personal-site', label: 'GitHub Repo' },
+      { href: '/support#lightning-tip-jar', label: 'Try Lightning Tip Jar' },
+    ],
+  },
 
   // --- Tools ---
   {
@@ -118,7 +108,7 @@ export const projects: Project[] = [
     status: 'contributor',
     tags: ['Terminal', 'AI', 'Open Source'],
     blurb:
-      'Contributed to Warp, the agentic terminal I use daily. Fixed repo-picker UX so multi-repo workflows are smoother — see PR #9451.',
+      'Contributed to Warp, the agentic terminal I use daily. Fixed repo-picker UX so multi-repo workflows are smoother. See PR #9451.',
     links: [
       { href: 'https://github.com/warpdotdev/warp/pull/9451', label: 'PR #9451' },
       { href: 'https://github.com/warpdotdev/warp/issues/9439', label: 'Issue #9439' },
@@ -141,8 +131,20 @@ export const projects: Project[] = [
     status: 'contributor',
     tags: ['Next.js', 'Lightning'],
     blurb:
-      'Contributor to the Plebnet website — site features and content for the broader Lightning Network community.',
+      'Contributor to the Plebnet website, building site features and content for the broader Lightning Network community.',
     links: [{ href: 'https://github.com/plebnet-dev/website', label: 'GitHub Repo' }],
+  },
+
+  // --- Track Record ---
+  {
+    id: 'gda-public-systems',
+    group: 'track-record',
+    title: 'Georgia DGA: Public Web & GIS Systems',
+    status: 'launched',
+    tags: ['Product leadership', 'GIS', 'Azure', 'C#', 'Public sector'],
+    blurb:
+      'IT Development Manager for state agency systems serving 50,000+ monthly users. Owned public-facing web roadmap, cut citizen wait times 40%, led enterprise ArcGIS program (Esri SAG award), and built cross-agency APIs for five partner organizations. Details available on request, no public repo.',
+    links: [{ href: '/Brandon_Sauceda_Resume.pdf', label: 'Résumé (PDF)' }],
   },
 ];
 
@@ -181,7 +183,8 @@ export const publications: Publication[] = [
 ];
 
 export const projectGroupLabels: Record<ProjectGroup, string> = {
-  apps: 'My Apps',
+  apps: 'Products',
   tools: 'Tools',
   'open-source': 'Open Source Contributions',
+  'track-record': 'Track Record',
 };

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,4 +1,5 @@
 export const SITE_NAME = 'Saucy.Tech';
+export const LEGAL_ENTITY = 'Saucy Tech LLC';
 export const SITE_DESCRIPTION = 'Love Jesus, Explore Ideas, Create Things, Save in Bitcoin';
 export const SITE_DESCRIPTION_HIRING =
   'Brandon Sauceda — IT Development Manager and software engineer. Gov-tech, GIS, full-stack web apps, and open source.';


### PR DESCRIPTION
Makes the operating company legible across the site as **Brandon + Saucy Tech LLC** without agency theater. Implements the Full tier of the positioning review across six components.

## Components
1. **Homepage** (`src/app/page.tsx`): positioning line directly under the bio ("Saucy Tech is my one-person company: I build my own software products and take on select client work"); new "Work with me" card → `/about#work-with-me`; relabel Portfolio card → "Projects". Bio, Writing card, Subscribe, Support untouched.
2. **Nav** (`src/config/site-nav.ts`): `Writing · Projects · About · Work with me · Field notes · Morning Portion · Support`. Bitcoin moved to footer; Latest dropped. Wordmark `Saucy.Tech` stays in header.
3. **New `/about`** (`src/app/about/page.tsx` + `src/data/about.ts`): person lead → what Saucy Tech does → products → track record → `#work-with-me` (raw `<section>` with `scroll-mt-24`). Sitemap entry + test assertion added.
4. **Projects regroup** (`src/data/projects.ts`, `src/app/portfolio/page.tsx`): "My Apps" → "Products"; new "Track Record" group. The Morning Portion is now flagship; Georgia DGA demoted to Track Record. Order: Products → Tools → Open Source → Track Record.
5. **Consulting**: low-key "Work with me" block on `/about`, single `mailto:brandon@saucy.tech` contact path. Nav item + homepage card both anchor to it.
6. **Footer/legal** (`src/utils/constants.ts`, `src/components/layout/Footer.tsx`): copyright now `Saucy Tech LLC` via new `LEGAL_ENTITY`; wordmark unchanged. Portfolio summary reframed.

## Voice pass
Deliberate em-dash cleanup on every touched file (notably `projects.ts`), per the no-em-dash / no-LLM-tells writing rules. New `/about` + `about.ts` prose manually checked clean of named LLM tells.

## Deviation from plan
Plan said "leave the `latestSlug` param." Once the Latest nav item was deleted, that param became dead, and with `noUnusedParameters: true` it breaks `next build` (TS6198). Removed the dead `latestSlug` threading from `getSiteNavItems`/`getFooterNavItems` and `layout.tsx` instead.

## Pinned-by-tests, left byte-for-byte
`portfolioAbout.resumeLabel` / `email` / `linkedIn`, the homepage `Writing` card.

## Verification (local)
- `pnpm lint` ✓
- jest: 119 passed (incl. sitemap `/about`, Profile) ✓
- `content:validate` / `check-links` / `check-images` / `security:drift` ✓
- `pnpm build` ✓ (`/about` route generated)
- Playwright smoke: 7/7 ✓ (résumé/email/LinkedIn + home Writing link intact)

🤖 Generated with [Claude Code](https://claude.com/claude-code)