### PR TITLE
fix(jest): anchor .claude ignore to repo root

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -13,7 +13,7 @@ const customJestConfig = {
     '^@/(.*)$': '<rootDir>/src/$1',
   },
   modulePathIgnorePatterns: ['<rootDir>/.claude/'],
-  testPathIgnorePatterns: ['/node_modules/', '/.next/', '/.claude/', '<rootDir>/tests/e2e/'],
+  testPathIgnorePatterns: ['/node_modules/', '/.next/', '<rootDir>/.claude/', '<rootDir>/tests/e2e/'],
 };
 
 module.exports = async () => {


### PR DESCRIPTION
## Problem

`testPathIgnorePatterns` in `jest.config.js` used an unanchored `'/.claude/'`. Jest matches these patterns against each test file's **absolute** path. When the repo is checked out under `.claude/worktrees/<name>/` (as background agents now do), every test path contains `/.claude/`, so **all tests were silently ignored** — `quality:gate` reported success while running zero tests.

## Fix

Anchor the pattern to `'<rootDir>/.claude/'`, matching the adjacent `modulePathIgnorePatterns` which was already correct. This only ignores the repo's own `.claude/` directory, not a `.claude` segment in an ancestor path.

```diff
- testPathIgnorePatterns: ['/node_modules/', '/.next/', '/.claude/', '<rootDir>/tests/e2e/'],
+ testPathIgnorePatterns: ['/node_modules/', '/.next/', '<rootDir>/.claude/', '<rootDir>/tests/e2e/'],
```

## Verification

- Ran `jest --listTests` from inside `.claude/worktrees/fix-jest-claude-ignore/`: **19 test files discovered** (was 0 before the fix).
- `pnpm quality:gate` passes (only pre-existing image-size / orphan-link warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)