### PR TITLE
feat(portfolio): ProfilePage JSON-LD + generated OG image

### DIFF
--- a/src/app/portfolio/opengraph-image.tsx
+++ b/src/app/portfolio/opengraph-image.tsx
@@ -1,0 +1,156 @@
+import { ImageResponse } from 'next/og';
+
+import { portfolioAbout } from '@/data/portfolio-about';
+
+export const alt = 'Brandon Sauceda — Portfolio';
+export const size = { width: 1200, height: 630 };
+export const contentType = 'image/png';
+
+const accent = '#F59E0B';
+const softAccent = 'rgba(245, 158, 11, 0.16)';
+const border = 'rgba(245, 158, 11, 0.34)';
+
+export default function OGImage() {
+  return new ImageResponse(
+    <div
+      style={{
+        width: '100%',
+        height: '100%',
+        display: 'flex',
+        flexDirection: 'column',
+        background: 'linear-gradient(145deg, #041714 0%, #07251F 40%, #0C332B 100%)',
+        padding: '56px',
+        position: 'relative',
+        overflow: 'hidden',
+      }}
+    >
+      <div
+        style={{
+          position: 'absolute',
+          top: '-180px',
+          right: '-120px',
+          width: '560px',
+          height: '560px',
+          borderRadius: '50%',
+          background: `radial-gradient(circle, ${softAccent} 0%, transparent 70%)`,
+        }}
+      />
+      <div
+        style={{
+          position: 'absolute',
+          bottom: '-220px',
+          left: '-120px',
+          width: '520px',
+          height: '520px',
+          borderRadius: '50%',
+          background: 'radial-gradient(circle, rgba(255,255,255,0.08) 0%, transparent 72%)',
+        }}
+      />
+      <div
+        style={{
+          display: 'flex',
+          flex: 1,
+          flexDirection: 'column',
+          justifyContent: 'space-between',
+          border: `1px solid ${border}`,
+          borderRadius: '34px',
+          background: 'linear-gradient(180deg, rgba(255,255,255,0.08), rgba(255,255,255,0.03))',
+          padding: '44px',
+          boxShadow: '0 24px 80px rgba(0, 0, 0, 0.28)',
+        }}
+      >
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+          }}
+        >
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              background: softAccent,
+              border: `1px solid ${border}`,
+              borderRadius: '999px',
+              padding: '10px 20px',
+              color: accent,
+              fontSize: '16px',
+              fontWeight: 700,
+              letterSpacing: '0.16em',
+              textTransform: 'uppercase',
+            }}
+          >
+            Portfolio
+          </div>
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              color: 'rgba(255,255,255,0.78)',
+              fontSize: '22px',
+              fontWeight: 700,
+              letterSpacing: '0.04em',
+            }}
+          >
+            saucy.tech
+          </div>
+        </div>
+
+        <div style={{ display: 'flex', flexDirection: 'column', gap: '26px', maxWidth: '920px' }}>
+          <div
+            style={{
+              display: 'flex',
+              color: '#FFFFFF',
+              fontSize: '76px',
+              fontWeight: 800,
+              lineHeight: 1.05,
+              letterSpacing: '-0.03em',
+            }}
+          >
+            {portfolioAbout.headline}
+          </div>
+          <div
+            style={{
+              display: 'flex',
+              color: accent,
+              fontSize: '28px',
+              fontWeight: 600,
+              letterSpacing: '0.01em',
+            }}
+          >
+            {portfolioAbout.title}
+          </div>
+        </div>
+
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: '14px',
+          }}
+        >
+          <div
+            style={{
+              width: '14px',
+              height: '14px',
+              borderRadius: '999px',
+              background: accent,
+            }}
+          />
+          <div
+            style={{
+              display: 'flex',
+              color: 'rgba(255,255,255,0.64)',
+              fontSize: '20px',
+              fontWeight: 500,
+            }}
+          >
+            Love Jesus. Explore Ideas. Create Things.
+          </div>
+        </div>
+      </div>
+    </div>,
+    { ...size }
+  );
+}

--- a/src/app/portfolio/page.tsx
+++ b/src/app/portfolio/page.tsx
@@ -1,4 +1,5 @@
 import { Metadata } from 'next';
+import { headers } from 'next/headers';
 
 import PageLayout from '@/components/PageLayout';
 import { Award, awards } from '@/data/awards';
@@ -12,29 +13,39 @@ import {
   talks,
   publications,
 } from '@/data/projects';
-import { SITE_NAME } from '@/utils/constants';
+import { SITE_NAME, absoluteUrl } from '@/utils/constants';
+import { getProfilePageJsonLd } from '@/utils/structured-data';
+
+const PORTFOLIO_OG_IMAGE = absoluteUrl('/portfolio/opengraph-image');
+
+const PORTFOLIO_DESCRIPTION =
+  'Brandon Sauceda — IT Development Manager and software engineer. Gov-tech, GIS, full-stack apps, open source, awards, and downloadable résumé.';
 
 export const metadata: Metadata = {
   title: 'Portfolio',
-  description:
-    'Brandon Sauceda — IT Development Manager and software engineer. Gov-tech, GIS, full-stack apps, open source, awards, and downloadable résumé.',
+  description: PORTFOLIO_DESCRIPTION,
   alternates: {
     canonical: '/portfolio',
   },
   openGraph: {
     title: 'Portfolio',
-    description:
-      'Brandon Sauceda — IT Development Manager and software engineer. Gov-tech, GIS, full-stack apps, open source, awards, and downloadable résumé.',
+    description: PORTFOLIO_DESCRIPTION,
     url: '/portfolio',
     type: 'profile',
     images: [
       {
-        url: '/headshot.jpeg',
-        width: 1024,
-        height: 1024,
+        url: PORTFOLIO_OG_IMAGE,
+        width: 1200,
+        height: 630,
         alt: `${SITE_NAME} - Portfolio`,
       },
     ],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Portfolio',
+    description: PORTFOLIO_DESCRIPTION,
+    images: [PORTFOLIO_OG_IMAGE],
   },
 };
 
@@ -116,15 +127,32 @@ function AwardCard({ award }: { award: Award }) {
   );
 }
 
-export default function Portfolio() {
+export default async function Portfolio() {
+  const nonce = (await headers()).get('x-nonce') ?? undefined;
   const projectGroups = GROUP_ORDER.map((group) => ({
     group,
     label: projectGroupLabels[group],
     items: projects.filter((p) => p.group === group),
   })).filter((g) => g.items.length > 0);
 
+  const jsonLd = getProfilePageJsonLd({
+    path: '/portfolio',
+    name: portfolioAbout.headline,
+    jobTitle: portfolioAbout.title,
+    description: portfolioAbout.summary,
+    imagePath: '/headshot.jpeg',
+    sameAs: [portfolioAbout.linkedIn, portfolioAbout.github, 'https://x.com/Saucy_Tech'],
+    dateModified: portfolioAboutLastUpdated,
+  });
+
   return (
     <PageLayout title="Portfolio">
+      <script
+        suppressHydrationWarning
+        type="application/ld+json"
+        {...(nonce ? { nonce } : {})}
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+      />
       <section className="flex flex-col gap-12 items-center">
         <section className="w-full max-w-xl text-center space-y-4 mb-4">
           <p className="text-sm uppercase tracking-widest text-(--text-secondary)">

--- a/src/utils/structured-data.test.ts
+++ b/src/utils/structured-data.test.ts
@@ -1,5 +1,10 @@
-import { getBlogListingJsonLd, getPostJsonLd, getSiteJsonLd } from '@/utils/structured-data';
-import { absoluteUrl } from '@/utils/constants';
+import {
+  getBlogListingJsonLd,
+  getPostJsonLd,
+  getProfilePageJsonLd,
+  getSiteJsonLd,
+} from '@/utils/structured-data';
+import { SITE_URL, absoluteUrl } from '@/utils/constants';
 
 describe('structured data helpers', () => {
   it('adds SearchAction to the website graph node', () => {
@@ -16,6 +21,44 @@ describe('structured data helpers', () => {
       target: absoluteUrl('/blog?query={search_term_string}'),
       'query-input': 'required name=search_term_string',
     });
+  });
+
+  it('builds ProfilePage JSON-LD with a Person mainEntity', () => {
+    const jsonLd = getProfilePageJsonLd({
+      path: '/portfolio',
+      name: 'Brandon Sauceda',
+      jobTitle: 'IT Development Manager · Software Engineer',
+      description: 'Ten years in Georgia government technology.',
+      imagePath: '/headshot.jpeg',
+      sameAs: ['https://github.com/saucy-tech'],
+      dateModified: '2026-05-21',
+    });
+
+    expect(jsonLd['@type']).toBe('ProfilePage');
+    expect(jsonLd.url).toBe(absoluteUrl('/portfolio'));
+    expect(jsonLd.dateModified).toBe('2026-05-21');
+    expect(jsonLd.mainEntity).toEqual({
+      '@type': 'Person',
+      name: 'Brandon Sauceda',
+      url: SITE_URL,
+      image: absoluteUrl('/headshot.jpeg'),
+      jobTitle: 'IT Development Manager · Software Engineer',
+      description: 'Ten years in Georgia government technology.',
+      sameAs: ['https://github.com/saucy-tech'],
+    });
+  });
+
+  it('omits dateModified from ProfilePage JSON-LD when not provided', () => {
+    const jsonLd = getProfilePageJsonLd({
+      path: '/portfolio',
+      name: 'Brandon Sauceda',
+      jobTitle: 'Software Engineer',
+      description: 'Builder.',
+      imagePath: '/headshot.jpeg',
+      sameAs: [],
+    });
+
+    expect(jsonLd).not.toHaveProperty('dateModified');
   });
 
   it('includes breadcrumb list for blog posts', () => {

--- a/src/utils/structured-data.ts
+++ b/src/utils/structured-data.ts
@@ -6,6 +6,16 @@ interface SiteJsonLdInput {
   sameAs: string[];
 }
 
+interface ProfilePageJsonLdInput {
+  path: string;
+  name: string;
+  jobTitle: string;
+  description: string;
+  imagePath: string;
+  sameAs: string[];
+  dateModified?: string;
+}
+
 interface PostJsonLdInput {
   slug: string;
   title: string;
@@ -62,6 +72,27 @@ export function getSiteJsonLd(input: SiteJsonLdInput): {
         },
       },
     ],
+  };
+}
+
+export function getProfilePageJsonLd(input: ProfilePageJsonLdInput): Record<string, unknown> {
+  const pageUrl = absoluteUrl(input.path);
+
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'ProfilePage',
+    url: pageUrl,
+    name: input.name,
+    ...(input.dateModified ? { dateModified: input.dateModified } : {}),
+    mainEntity: {
+      '@type': 'Person',
+      name: input.name,
+      url: SITE_URL,
+      image: absoluteUrl(input.imagePath),
+      jobTitle: input.jobTitle,
+      description: input.description,
+      sameAs: input.sameAs,
+    },
   };
 }
 


### PR DESCRIPTION
## What

Adds `Person`/`ProfilePage` JSON-LD to the about page (`/portfolio`) matching the homepage Person pattern, and replaces the headshot OG image with a branded generated image.

> Note: there is no `/about` route in this repo. The about-me page is `/portfolio` (`portfolio-about.ts`, `type: 'profile'`, previously used the headshot as its OG image), so the work landed there.

## Changes

- **`src/utils/structured-data.ts`** — new `getProfilePageJsonLd()`: `ProfilePage` → `mainEntity` `Person`, mirroring the homepage Person node (name, `url: SITE_URL`, image, `sameAs`) plus `jobTitle`, `description`, optional `dateModified`.
- **`src/app/portfolio/opengraph-image.tsx`** — new static 1200×630 branded OG card (same visual language as the blog OG route, no `[slug]` params machinery).
- **`src/app/portfolio/page.tsx`** — point `og:image` + `twitter:image` at the generated route (twitter card added; page had none, so it was inheriting the layout headshot), inject nonce'd JSON-LD `<script>` (component now `async` to read `headers()`).
- **`src/utils/structured-data.test.ts`** — 2 new tests.

## Verification

- `pnpm lint`, `tsc --noEmit` clean; 121 unit tests pass; `pnpm build` passes (`/portfolio/opengraph-image` prerenders static).
- Runtime check against `next start`: `/portfolio` renders `ProfilePage` JSON-LD with a live nonce (not CSP-blocked); `og:image` + `twitter:image` point at the generated image; `/portfolio/opengraph-image` returns `200 image/png`. The only remaining `headshot.jpeg` reference is the Person's photo inside the JSON-LD (intentional, matches homepage).

Note: `/portfolio` is now server-rendered on demand (reads `headers()` for the nonce), same tradeoff as the homepage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)