### PR TITLE
style: remove last em dash from bitcoin page

### DIFF
--- a/src/app/bitcoin/page.tsx
+++ b/src/app/bitcoin/page.tsx
@@ -253,7 +253,7 @@ export default function Bitcoin() {
             <Link href="/field-notes" className="text-blue-400 underline">
               Field notes
             </Link>{' '}
-            — how I use AI day to day (models, harnesses, subscriptions, gear).
+            covers how I use AI day to day (models, harnesses, subscriptions, gear).
           </p>
         </div>
       </section>


### PR DESCRIPTION
Voice-sweep cleanup. The Bitcoin page's Field notes link blurb still used an em dash; swapped to plain wording.

The rest of the approved sweep (homepage card titles, faith/Bitcoin card wording, and the Bitcoin testimony body) already landed on `main` directly, so this is the only remaining change.

Left untouched: the 13 en dashes (`–`) used as separators in the Bitcoin resource list — those are list punctuation, not em dashes, and out of the approved testimony scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)