### PR TITLE
fix: disarm devotion broadcast label trigger, guard invoice route

### DIFF
--- a/.github/workflows/devotion-broadcast.yml
+++ b/.github/workflows/devotion-broadcast.yml
@@ -1,33 +1,32 @@
 name: Devotion Broadcast
 
-# Triggers when a PR with the "devotion" label is merged into main.
-# Can also be triggered manually via workflow_dispatch with a post slug.
+# Manual dispatch only. Devotion authoring moved to the-morning-portion repo;
+# the PR-label trigger was removed 2026-06-10 so a stray "devotion" label can
+# never email subscribers from this archive. Requires typing SEND to confirm.
 
 on:
-  pull_request:
-    types: [closed]
-    branches: [main]
   workflow_dispatch:
     inputs:
       slug:
         description: 'Post slug (e.g. 2026-03-18-the-word-that-mattered-most)'
         required: true
         type: string
+      confirm:
+        description: 'Type SEND to confirm emailing all Kit subscribers'
+        required: true
+        type: string
+
+concurrency:
+  group: devotion-broadcast
+  cancel-in-progress: false
 
 jobs:
   broadcast:
     name: Send Kit Broadcast
-    # On PR: only run when merged with the "devotion" label.
-    # On manual dispatch: always run.
-    if: >
-      github.event_name == 'workflow_dispatch' ||
-      (github.event.pull_request.merged == true &&
-       contains(github.event.pull_request.labels.*.name, 'devotion'))
+    if: github.event.inputs.confirm == 'SEND'
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      issues: write
-      pull-requests: write
 
     steps:
       - name: Checkout
@@ -35,34 +34,17 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Find new devotion post
+      - name: Find devotion post
         id: post
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            NEW_FILE="src/posts/${{ inputs.slug }}.mdx"
-            if [ ! -f "$NEW_FILE" ]; then
-              echo "::error::Post file not found: $NEW_FILE"
-              echo "skip=true" >> "$GITHUB_OUTPUT"
-            else
-              echo "file=$NEW_FILE" >> "$GITHUB_OUTPUT"
-              echo "skip=false" >> "$GITHUB_OUTPUT"
-              echo "Found post: $NEW_FILE"
-            fi
+          NEW_FILE="src/posts/${{ inputs.slug }}.mdx"
+          if [ ! -f "$NEW_FILE" ]; then
+            echo "::error::Post file not found: $NEW_FILE"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
           else
-            BASE="${{ github.event.pull_request.base.sha }}"
-            HEAD="${{ github.event.pull_request.merge_commit_sha }}"
-            echo "Checking diff: $BASE → $HEAD"
-
-            NEW_FILE=$(git diff --name-only --diff-filter=A "$BASE" "$HEAD" -- 'src/posts/*.mdx' | sort -r | head -1)
-
-            if [ -z "$NEW_FILE" ]; then
-              echo "No new MDX post found in this PR — skipping broadcast."
-              echo "skip=true" >> "$GITHUB_OUTPUT"
-            else
-              echo "file=$NEW_FILE" >> "$GITHUB_OUTPUT"
-              echo "skip=false" >> "$GITHUB_OUTPUT"
-              echo "Found post: $NEW_FILE"
-            fi
+            echo "file=$NEW_FILE" >> "$GITHUB_OUTPUT"
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+            echo "Found post: $NEW_FILE"
           fi
 
       - name: Extract post metadata
@@ -330,27 +312,3 @@ jobs:
             echo "post_url=${POST_URL}"
           } >> "$GITHUB_OUTPUT"
           echo "✓ Broadcast created (ID: ${BROADCAST_ID:-unknown}), scheduled for $SEND_AT"
-
-      - name: Comment on PR
-        if: steps.post.outputs.skip == 'false' && github.event_name == 'pull_request'
-        continue-on-error: true
-        env:
-          GH_TOKEN: ${{ github.token }}
-          POST_URL: ${{ steps.send_broadcast.outputs.post_url }}
-          BROADCAST_ID: ${{ steps.send_broadcast.outputs.broadcast_id }}
-        run: |
-          COMMENT_BODY=$(cat <<EOF
-          **The Daily Word broadcast sent!**
-
-          Post URL: ${POST_URL}
-          Broadcast ID: ${BROADCAST_ID:-unknown}
-
-          The broadcast has been scheduled to send to all Daily Word subscribers via Kit.
-          EOF
-          )
-
-          if gh pr comment ${{ github.event.pull_request.number }} --body "$COMMENT_BODY"; then
-            echo "Posted PR comment for broadcast ${BROADCAST_ID:-unknown}."
-          else
-            echo "::warning::Failed to post PR comment for broadcast ${BROADCAST_ID:-unknown}. The broadcast succeeded and the workflow will continue."
-          fi

--- a/scripts/auto-broadcast.ts
+++ b/scripts/auto-broadcast.ts
@@ -157,6 +157,7 @@ async function main() {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(body),
+      signal: AbortSignal.timeout(30_000),
     }
   );
 

--- a/src/app/api/invoice/route.ts
+++ b/src/app/api/invoice/route.ts
@@ -85,6 +85,11 @@ export async function POST(request: NextRequest) {
         description: memoValidation.sanitized || 'Lightning Tip Jar',
       });
 
+      if (!result?.invoice || !result.payment_hash) {
+        console.error('Nostr Wallet Connect makeInvoice returned no invoice');
+        return createSecureErrorResponse('Unable to process payment request', 503);
+      }
+
       const paymentRequest = result.invoice;
       const paymentHash = result.payment_hash;
 


### PR DESCRIPTION
## What

Implements the top recommendation from today's deep audit (C1 + critical null-check fix):

**`.github/workflows/devotion-broadcast.yml` — disarmed**
- Removed the `pull_request` + `devotion`-label trigger entirely. Devotion authoring moved to `the-morning-portion`; this repo is an archive, and a mislabeled merge here could email every Kit subscriber.
- `workflow_dispatch` now requires a `confirm` input that must equal `SEND`.
- Added a `concurrency` group (`devotion-broadcast`, no cancel) so re-runs cannot overlap and double-send.
- Removed now-dead PR-diff post discovery and PR-comment steps; tightened permissions to `contents: read`.

**`scripts/auto-broadcast.ts`**
- Kit/ConvertKit API call now has a 30s `AbortSignal.timeout` — previously could hang forever.

**`src/app/api/invoice/route.ts`**
- Null guard on NWC `makeInvoice` result: missing `invoice`/`payment_hash` now returns 503 instead of throwing a TypeError (500).

## Not in scope (follow-ups from the audit)

- C2: single Post Archive module (3 duplicate frontmatter parsers)
- C3: structural CSP drift check + delete dead `security-monitor.ts`
- C4: Node version alignment, pre-push hook, e2e contract suite

## Verification

- `pnpm quality:gate` passes (lint, jest, content validate, links, images, security drift) — only pre-existing warnings (orphan posts, large images).
- Workflow YAML parses clean.
- Targeted jest suites for invoice route + auto-broadcast: 14/14 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)