### PR TITLE
Fit worker in free-plan size cap; fix /api/btcusd on Workers

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "quality:gate": "pnpm lint && pnpm test && pnpm content:validate && pnpm content:check-links && pnpm content:check-images && pnpm security:drift",
     "docs:architecture": "ts-node --project tsconfig.scripts.json scripts/generate-architecture-docs.ts",
     "preview": "opennextjs-cloudflare build && opennextjs-cloudflare preview",
-    "deploy": "opennextjs-cloudflare build && opennextjs-cloudflare deploy -- --keep-vars",
+    "deploy": "opennextjs-cloudflare build && node scripts/cf-slim-og.mjs && opennextjs-cloudflare deploy -- --keep-vars",
     "cf-typegen": "wrangler types --env-interface CloudflareEnv cloudflare-env.d.ts"
   },
   "lint-staged": {

--- a/scripts/cf-slim-og.mjs
+++ b/scripts/cf-slim-og.mjs
@@ -1,0 +1,37 @@
+#!/usr/bin/env node
+// Replaces @vercel/og wasm/font payloads in .open-next with tiny valid
+// placeholders before `wrangler deploy` bundles them. OG images are fully
+// prerendered at build time (generateStaticParams + dynamicParams = false),
+// so these modules are unreachable at runtime; shipping them costs ~600 KiB
+// of the 3 MiB free-plan gzip budget.
+import { readdirSync, rmSync, statSync, writeFileSync } from 'node:fs';
+import { join, sep } from 'node:path';
+
+const EMPTY_WASM = Buffer.from([0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00]);
+const OG_DIR = `${sep}@vercel${sep}og${sep}`;
+
+function* walk(dir) {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      yield* walk(path);
+    } else {
+      yield path;
+    }
+  }
+}
+
+let replaced = 0;
+for (const file of walk('.open-next')) {
+  if (!file.includes(OG_DIR) || !/\.(wasm|bin)$/.test(file)) continue;
+  const kib = (statSync(file).size / 1024).toFixed(0);
+  rmSync(file); // break hard links before rewriting
+  writeFileSync(file, file.endsWith('.wasm') ? EMPTY_WASM : Buffer.alloc(0));
+  console.log(`cf-slim-og: ${file} (${kib} KiB -> placeholder)`);
+  replaced += 1;
+}
+
+if (replaced === 0) {
+  console.error('cf-slim-og: no @vercel/og wasm/bin files found — bundle layout changed?');
+  process.exit(1);
+}

--- a/src/app/api/btcusd/route.test.ts
+++ b/src/app/api/btcusd/route.test.ts
@@ -42,7 +42,9 @@ describe('GET /api/btcusd', () => {
 
   it('returns MISS with cache-control header on first fetch', async () => {
     (global.fetch as jest.Mock).mockResolvedValueOnce(
-      new Response(JSON.stringify({ bitcoin: { usd: 65000 } }), { status: 200 })
+      new Response(JSON.stringify({ data: { amount: '65000.00', base: 'BTC', currency: 'USD' } }), {
+        status: 200,
+      })
     );
     const { GET } = await import('@/app/api/btcusd/route');
     const response = await GET(makeRequest());
@@ -54,7 +56,9 @@ describe('GET /api/btcusd', () => {
 
   it('returns HIT when cached value exists', async () => {
     (global.fetch as jest.Mock).mockResolvedValueOnce(
-      new Response(JSON.stringify({ bitcoin: { usd: 65000 } }), { status: 200 })
+      new Response(JSON.stringify({ data: { amount: '65000.00', base: 'BTC', currency: 'USD' } }), {
+        status: 200,
+      })
     );
     const { GET } = await import('@/app/api/btcusd/route');
     await GET(makeRequest());
@@ -82,7 +86,10 @@ describe('GET /api/btcusd', () => {
 
   it('returns 502 when upstream payload shape is invalid', async () => {
     (global.fetch as jest.Mock).mockResolvedValueOnce(
-      new Response(JSON.stringify({ bitcoin: { usd: 'not-a-number' } }), { status: 200 })
+      new Response(
+        JSON.stringify({ data: { amount: 'not-a-number', base: 'BTC', currency: 'USD' } }),
+        { status: 200 }
+      )
     );
     const { GET } = await import('@/app/api/btcusd/route');
     const response = await GET(makeRequest());

--- a/src/app/api/btcusd/route.ts
+++ b/src/app/api/btcusd/route.ts
@@ -51,20 +51,18 @@ export async function GET(request: NextRequest) {
     const timeoutId = setTimeout(() => controller.abort(), SECURITY_CONSTANTS.REQUEST_TIMEOUT);
 
     try {
-      const response = await fetch(
-        'https://api.coingecko.com/api/v3/simple/price?ids=bitcoin&vs_currencies=usd',
-        {
-          signal: controller.signal,
-          headers: {
-            'User-Agent': 'Personal-Site/1.0',
-          },
-        }
-      );
+      // Coinbase spot API: CoinGecko's WAF blocks fetches from Cloudflare Workers.
+      const response = await fetch('https://api.coinbase.com/v2/prices/BTC-USD/spot', {
+        signal: controller.signal,
+        headers: {
+          'User-Agent': 'Personal-Site/1.0',
+        },
+      });
 
       clearTimeout(timeoutId);
 
       if (!response.ok) {
-        logApiEvent('error', '/api/btcusd', 'coingecko_error_response', {
+        logApiEvent('error', '/api/btcusd', 'coinbase_error_response', {
           status: response.status,
           statusText: response.statusText,
         });
@@ -74,8 +72,9 @@ export async function GET(request: NextRequest) {
       const data = await response.json();
 
       // Validate response structure
-      if (data && data.bitcoin && typeof data.bitcoin.usd === 'number' && data.bitcoin.usd > 0) {
-        cachedRate = data.bitcoin.usd;
+      const usd = Number.parseFloat(data?.data?.amount);
+      if (Number.isFinite(usd) && usd > 0) {
+        cachedRate = usd;
         lastFetchTime = Date.now();
         return NextResponse.json(
           { usd: cachedRate },
@@ -88,25 +87,25 @@ export async function GET(request: NextRequest) {
           }
         );
       } else {
-        // If CoinGecko's response format is unexpected, return an error
-        logApiEvent('error', '/api/btcusd', 'coingecko_invalid_payload', {
+        // If Coinbase's response format is unexpected, return an error
+        logApiEvent('error', '/api/btcusd', 'coinbase_invalid_payload', {
           responseData: data,
         });
         return createSecureErrorResponse(
           'Failed to parse price data',
           502,
-          'Invalid CoinGecko response format'
+          'Invalid Coinbase response format'
         );
       }
     } catch (fetchError) {
       clearTimeout(timeoutId);
 
       if (fetchError instanceof Error && fetchError.name === 'AbortError') {
-        logApiEvent('error', '/api/btcusd', 'coingecko_timeout');
+        logApiEvent('error', '/api/btcusd', 'coinbase_timeout');
         return createSecureErrorResponse('Price data request timeout', 504);
       }
 
-      logApiEvent('error', '/api/btcusd', 'coingecko_request_failed', {
+      logApiEvent('error', '/api/btcusd', 'coinbase_request_failed', {
         message: fetchError instanceof Error ? fetchError.message : 'unknown',
       });
       return createSecureErrorResponse('Failed to fetch price data', 502);

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -4,6 +4,8 @@
   "main": ".open-next/worker.js",
   "compatibility_date": "2026-06-01",
   "compatibility_flags": ["nodejs_compat", "global_fetch_strictly_public"],
+  // Free-plan worker budget is 3 MiB gzipped; minify keeps us under it.
+  "minify": true,
   "assets": {
     "directory": ".open-next/assets",
     "binding": "ASSETS"


### PR DESCRIPTION
## Why

Migration manual task **p2-4** (deploy personal-site to workers.dev). Two blockers surfaced:

1. **Worker size**: OpenNext bundle was 3.4 MiB gzipped vs the 3 MiB free-plan cap (deploy rejected, code 10027).
2. **/api/btcusd returned 502**: CoinGecko's WAF blocks fetches from Cloudflare Workers egress IPs.

## What

- `scripts/cf-slim-og.mjs` — post-build step that replaces the runtime `@vercel/og` wasm/font payloads (~600 KiB gzipped) with placeholders. OG images are fully prerendered at build time (`generateStaticParams` + `dynamicParams = false`), so these modules are unreachable at runtime. Wired into `pnpm run deploy` between build and deploy.
- `wrangler.jsonc` — `"minify": true`.
- `/api/btcusd` — upstream switched CoinGecko → Coinbase spot (`api.coinbase.com/v2/prices/BTC-USD/spot`, keyless). Response contract `{ usd: number }` unchanged; tests updated to the Coinbase payload shape.

Bundle: **3473 → 2495 KiB gzipped** (577 KiB under cap).

## Verified on workers.dev (version d612f3a4)

- `/`, `/blog`, blog post, `/rss.xml` — 200
- `/portfolio/opengraph-image` + per-post OG images — 200 `image/png` (prerendered, slim-og safe)
- `/api/btcusd` — 200 `{"usd":63523.915}`
- `/.well-known/lnurlp/brandon` — 200, valid payRequest metadata
- `pnpm check` (lint, tsc, 121 jest tests) + `security:drift` — pass

## Notes

- `src/utils/security.ts` CSP `connect-src` still allowlists `api.coingecko.com` — browser never fetched it directly, left untouched (drift check pins CSP).
- Subscribe + tip flow verification pending Cloudflare secrets (NWC, ConvertKit, Upstash, Sentry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)