### PR TITLE
Upgrade subscribe form to Kit v4 API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -51,7 +51,8 @@ LNURL_METADATA_DESC="Lightning tip jar for brandon"
 # OPTIONAL - Email Newsletter Integration
 # =============================================================================
 
-# ConvertKit API configuration for email subscriptions (subscribe form)
+# Kit (ConvertKit) configuration for email subscriptions (subscribe form)
+# CONVERTKIT_API_KEY is a Kit v4 API key (kit_…) from Settings → Developer
 CONVERTKIT_API_KEY=
 CONVERTKIT_FORM_ID=
 

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "quality:gate": "pnpm lint && pnpm test && pnpm content:validate && pnpm content:check-links && pnpm content:check-images && pnpm security:drift",
     "docs:architecture": "ts-node --project tsconfig.scripts.json scripts/generate-architecture-docs.ts",
     "preview": "opennextjs-cloudflare build && opennextjs-cloudflare preview",
-    "deploy": "opennextjs-cloudflare build && node scripts/cf-slim-og.mjs && opennextjs-cloudflare deploy -- --keep-vars",
+    "build:worker": "opennextjs-cloudflare build && node scripts/cf-slim-og.mjs",
+    "deploy": "pnpm run build:worker && opennextjs-cloudflare deploy -- --keep-vars",
     "cf-typegen": "wrangler types --env-interface CloudflareEnv cloudflare-env.d.ts"
   },
   "lint-staged": {

--- a/src/app/api/subscribe/route.test.ts
+++ b/src/app/api/subscribe/route.test.ts
@@ -67,14 +67,23 @@ describe('POST /api/subscribe', () => {
   });
 
   it('returns 200 with success=true on the happy path', async () => {
-    (global.fetch as jest.Mock).mockResolvedValueOnce(
-      new Response(JSON.stringify({ subscriber: {} }), { status: 200 })
-    );
+    (global.fetch as jest.Mock)
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ subscriber: { id: 767 } }), { status: 201 })
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ subscriber: { id: 767 } }), { status: 201 })
+      );
 
     const response = await POST(makeRequest({ email: 'user@example.com' }));
 
     expect(response.status).toBe(200);
     await expect(response.json()).resolves.toEqual({ success: true });
+    expect(global.fetch).toHaveBeenCalledTimes(2);
+    expect((global.fetch as jest.Mock).mock.calls[0][0]).toBe('https://api.kit.com/v4/subscribers');
+    expect((global.fetch as jest.Mock).mock.calls[1][0]).toBe(
+      'https://api.kit.com/v4/forms/test-form-id/subscribers/767'
+    );
   });
 
   it('returns 200 when honeypot company field is filled (silent drop)', async () => {
@@ -85,10 +94,14 @@ describe('POST /api/subscribe', () => {
     expect(global.fetch).not.toHaveBeenCalled();
   });
 
-  it('returns 200 when ConvertKit reports already subscribed', async () => {
-    (global.fetch as jest.Mock).mockResolvedValueOnce(
-      new Response(JSON.stringify({ message: 'Subscriber already subscribed' }), { status: 400 })
-    );
+  it('returns 200 with alreadySubscribed when Kit reports the form membership exists', async () => {
+    (global.fetch as jest.Mock)
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ subscriber: { id: 767 } }), { status: 200 })
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ subscriber: { id: 767 } }), { status: 200 })
+      );
 
     const response = await POST(makeRequest({ email: 'user@example.com' }));
 
@@ -110,9 +123,9 @@ describe('POST /api/subscribe', () => {
     expect(response.status).toBe(400);
   });
 
-  it('returns 502 when ConvertKit returns a non-2xx status', async () => {
+  it('returns 502 when Kit returns a non-2xx status', async () => {
     (global.fetch as jest.Mock).mockResolvedValueOnce(
-      new Response(JSON.stringify({ error: 'server error' }), { status: 500 })
+      new Response(JSON.stringify({ errors: ['server error'] }), { status: 500 })
     );
 
     const response = await POST(makeRequest({ email: 'user@example.com' }));
@@ -134,8 +147,8 @@ describe('POST /api/subscribe', () => {
   it('returns 429 after exceeding the rate limit for one IP', async () => {
     const ip = uniqueIP();
 
-    (global.fetch as jest.Mock).mockResolvedValue(
-      new Response(JSON.stringify({ subscriber: {} }), { status: 200 })
+    (global.fetch as jest.Mock).mockImplementation(() =>
+      Promise.resolve(new Response(JSON.stringify({ subscriber: { id: 767 } }), { status: 200 }))
     );
 
     for (let i = 0; i < 5; i += 1) {

--- a/src/app/api/subscribe/route.ts
+++ b/src/app/api/subscribe/route.ts
@@ -127,11 +127,13 @@ export async function POST(req: NextRequest) {
         return createSecureErrorResponse('Failed to subscribe', 502);
       }
 
+      const referrer = req.headers.get('referer');
       const formResponse = await fetch(
         `https://api.kit.com/v4/forms/${formId}/subscribers/${subscriberId}`,
         {
           method: 'POST',
           headers: kitHeaders,
+          body: JSON.stringify(referrer ? { referrer } : {}),
           signal: controller.signal,
         }
       );

--- a/src/app/api/subscribe/route.ts
+++ b/src/app/api/subscribe/route.ts
@@ -9,6 +9,7 @@ import {
   SECURITY_CONSTANTS,
 } from '@/utils/security';
 import { logApiEvent, logStructured } from '@/utils/logger';
+import { SITE_URL } from '@/utils/constants';
 
 type SubscribeBody = {
   email?: unknown;
@@ -127,13 +128,13 @@ export async function POST(req: NextRequest) {
         return createSecureErrorResponse('Failed to subscribe', 502);
       }
 
-      const referrer = req.headers.get('referer');
+      const referrer = req.headers.get('referer') || SITE_URL;
       const formResponse = await fetch(
         `https://api.kit.com/v4/forms/${formId}/subscribers/${subscriberId}`,
         {
           method: 'POST',
           headers: kitHeaders,
-          body: JSON.stringify(referrer ? { referrer } : {}),
+          body: JSON.stringify({ referrer }),
           signal: controller.signal,
         }
       );

--- a/src/app/api/subscribe/route.ts
+++ b/src/app/api/subscribe/route.ts
@@ -17,37 +17,15 @@ type SubscribeBody = {
   website?: unknown;
 };
 
-function extractConvertKitMessage(data: unknown): string {
+function extractKitErrors(data: unknown): string {
   if (!data || typeof data !== 'object') {
     return '';
   }
-  const rec = data as Record<string, unknown>;
-  if (typeof rec.message === 'string') {
-    return rec.message;
-  }
-  const err = rec.error;
-  if (typeof err === 'string') {
-    return err;
-  }
-  if (
-    err &&
-    typeof err === 'object' &&
-    'message' in err &&
-    typeof (err as { message: unknown }).message === 'string'
-  ) {
-    return (err as { message: string }).message;
+  const errors = (data as Record<string, unknown>).errors;
+  if (Array.isArray(errors)) {
+    return errors.filter((e): e is string => typeof e === 'string').join('; ');
   }
   return '';
-}
-
-function isAlreadySubscribedMessage(message: string): boolean {
-  const m = message.toLowerCase();
-  return (
-    m.includes('already subscribed') ||
-    m.includes('already a subscriber') ||
-    m.includes('subscriber already') ||
-    m.includes('already exists')
-  );
 }
 
 export async function POST(req: NextRequest) {
@@ -111,36 +89,67 @@ export async function POST(req: NextRequest) {
     const timeoutId = setTimeout(() => controller.abort(), SECURITY_CONSTANTS.REQUEST_TIMEOUT);
 
     try {
-      const response = await fetch(`https://api.convertkit.com/v3/forms/${formId}/subscribe`, {
+      // Kit v4 API: upsert the subscriber, then attach them to the form.
+      const kitHeaders = {
+        'Content-Type': 'application/json',
+        'User-Agent': 'Personal-Site/1.0',
+        'X-Kit-Api-Key': apiKey,
+      };
+
+      const createResponse = await fetch('https://api.kit.com/v4/subscribers', {
         method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'User-Agent': 'Personal-Site/1.0',
-        },
-        body: JSON.stringify({
-          email: emailValidation.sanitized,
-          api_key: apiKey,
-        }),
+        headers: kitHeaders,
+        body: JSON.stringify({ email_address: emailValidation.sanitized }),
         signal: controller.signal,
       });
 
-      clearTimeout(timeoutId);
+      const createData: unknown = await createResponse.json().catch(() => ({}));
 
-      if (!response.ok) {
-        const data: unknown = await response.json().catch(() => ({}));
-        const message = extractConvertKitMessage(data);
-        if (isAlreadySubscribedMessage(message)) {
-          return NextResponse.json({ success: true, alreadySubscribed: true });
-        }
-        logApiEvent('error', '/api/subscribe', 'convertkit_error_response', {
-          status: response.status,
-          responseData: data,
+      if (!createResponse.ok) {
+        logApiEvent('error', '/api/subscribe', 'kit_create_subscriber_error', {
+          status: createResponse.status,
+          responseData: createData,
         });
         const clientMessage =
-          response.status === 400 && message
+          createResponse.status === 422 && extractKitErrors(createData)
             ? 'Please check your email address and try again.'
             : 'Failed to subscribe';
+        clearTimeout(timeoutId);
         return createSecureErrorResponse(clientMessage, 502);
+      }
+
+      const subscriberId = (createData as { subscriber?: { id?: unknown } })?.subscriber?.id;
+      if (typeof subscriberId !== 'number') {
+        clearTimeout(timeoutId);
+        logApiEvent('error', '/api/subscribe', 'kit_invalid_subscriber_payload', {
+          responseData: createData,
+        });
+        return createSecureErrorResponse('Failed to subscribe', 502);
+      }
+
+      const formResponse = await fetch(
+        `https://api.kit.com/v4/forms/${formId}/subscribers/${subscriberId}`,
+        {
+          method: 'POST',
+          headers: kitHeaders,
+          signal: controller.signal,
+        }
+      );
+
+      clearTimeout(timeoutId);
+
+      if (!formResponse.ok) {
+        const formData: unknown = await formResponse.json().catch(() => ({}));
+        logApiEvent('error', '/api/subscribe', 'kit_add_to_form_error', {
+          status: formResponse.status,
+          responseData: formData,
+        });
+        return createSecureErrorResponse('Failed to subscribe', 502);
+      }
+
+      // 200 = was already on the form; 201 = newly added.
+      if (formResponse.status === 200) {
+        return NextResponse.json({ success: true, alreadySubscribed: true });
       }
 
       return NextResponse.json({ success: true });


### PR DESCRIPTION
## Why

The subscribe route called ConvertKit's v3 forms endpoint, which rejects Kit v4 (`kit_…`) API keys with "API Key not valid". The account's current key is v4.

## What

- `/api/subscribe` now uses the Kit v4 flow: upsert subscriber (`POST /v4/subscribers`), then attach to the form (`POST /v4/forms/{form_id}/subscribers/{id}`), authenticated via `X-Kit-Api-Key`.
- Response contract unchanged: `{ success: true }`, plus `alreadySubscribed: true` when the form-add returns 200 (existing membership) instead of 201.
- v3-specific "already subscribed" message sniffing removed (v4 upsert makes it structural).
- Tests updated to the two-call flow; `.env.example` documents that `CONVERTKIT_API_KEY` is a v4 key.

## Verified

- `pnpm check` — lint, tsc, 121 tests pass.
- Live on workers.dev with the v4 key: new email → `{"success":true}`; repeat → `{"success":true,"alreadySubscribed":true}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)