### PR TITLE
fix(home): prerender homepage so it works on Cloudflare Workers

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,6 +6,7 @@ import Header from '@/components/layout/Header';
 import Footer from '@/components/layout/Footer';
 import { getFooterNavItems, getSiteNavItems } from '@/config/site-nav';
 import { SITE_NAME, SITE_DESCRIPTION_HIRING, SITE_URL } from '@/utils/constants';
+import { getSiteJsonLd } from '@/utils/structured-data';
 import { APPEARANCE_STORAGE_KEY, THEME_STORAGE_KEY } from '@/utils/theme';
 import ClientGalaxyBackground from '@/components/ClientGalaxyBackground';
 import { Analytics } from '@vercel/analytics/next';
@@ -98,6 +99,18 @@ export default async function RootLayout({ children }: { children: React.ReactNo
   const nonce = (await headers()).get('x-nonce') ?? undefined;
   const navItems = getSiteNavItems();
   const footerNavItems = getFooterNavItems();
+  // Site-level structured data (Person + WebSite). Rendered here, in the dynamic
+  // layout, so it carries the per-request nonce and stays CSP-compliant. The home
+  // page is statically prerendered and cannot emit a nonced inline script.
+  const siteJsonLd = getSiteJsonLd({
+    authorName: 'Brandon',
+    authorImagePath: '/headshot.jpeg',
+    sameAs: [
+      'https://x.com/Saucy_Tech',
+      'https://github.com/saucy-tech',
+      'https://primal.net/p/nprofile1qqsvzs8gfntzjs2wg8670nrfy64h44zy69kc3r8rp5wd7kw6t6njsassf62c7',
+    ],
+  });
   return (
     <html lang="en" suppressHydrationWarning>
       <head>
@@ -107,6 +120,12 @@ export default async function RootLayout({ children }: { children: React.ReactNo
           dangerouslySetInnerHTML={{
             __html: `(function(){try{var t=${JSON.stringify(THEME_STORAGE_KEY)};var a=${JSON.stringify(APPEARANCE_STORAGE_KEY)};if(localStorage.getItem(t)==='green')document.documentElement.setAttribute('data-theme','green');if(localStorage.getItem(a)==='light')document.documentElement.setAttribute('data-appearance','light');}catch(e){}})();`,
           }}
+        />
+        <script
+          suppressHydrationWarning
+          type="application/ld+json"
+          {...(nonce ? { nonce } : {})}
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(siteJsonLd) }}
         />
       </head>
       <body className={`${ibmSans.variable} ${ibmMono.variable} font-sans antialiased`}>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,5 @@
 import Image from 'next/image';
 import Link from 'next/link';
-import { headers } from 'next/headers';
 import type { Metadata } from 'next';
 
 import LinkCard from '@/components/LinkCard';
@@ -10,7 +9,6 @@ import SocialBar from '@/components/SocialBar';
 import SubscribeForm from '@/components/SubscribeForm';
 import { formatPostDate } from '@/utils/helpers';
 import { getAllPostsMeta } from '@/utils/posts';
-import { getSiteJsonLd } from '@/utils/structured-data';
 
 export const metadata: Metadata = {
   alternates: {
@@ -22,7 +20,6 @@ export const metadata: Metadata = {
 };
 
 export default async function Home() {
-  const nonce = (await headers()).get('x-nonce') ?? undefined;
   const profileData = {
     name: 'Brandon',
     bio: 'Love Jesus, Explore Ideas, Create Things, Save in Bitcoin',
@@ -87,24 +84,8 @@ export default async function Home() {
   const posts = getAllPostsMeta();
   const latest = posts[0];
 
-  const jsonLd = getSiteJsonLd({
-    authorName: 'Brandon',
-    authorImagePath: '/headshot.jpeg',
-    sameAs: [
-      'https://x.com/Saucy_Tech',
-      'https://github.com/saucy-tech',
-      'https://primal.net/p/nprofile1qqsvzs8gfntzjs2wg8670nrfy64h44zy69kc3r8rp5wd7kw6t6njsassf62c7',
-    ],
-  });
-
   return (
     <div className="pt-4 pb-6 px-4 md:px-8 flex flex-col items-center">
-      <script
-        suppressHydrationWarning
-        type="application/ld+json"
-        {...(nonce ? { nonce } : {})}
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
-      />
       <div className="space-y-6 w-full max-w-lg mx-auto">
         <div className="space-y-2">
           <Profile {...profileData} />


### PR DESCRIPTION
## Problem

The homepage on the new Cloudflare Workers deployment renders the error boundary ("Something went wrong"). Every other page works.

## Root cause (verified in local workerd)

- On Workers the runtime `process.cwd()` is `/bundle`, and `src/posts` is **not** present at `/bundle/src/posts` in the worker filesystem.
- `getAllPostsMeta()` reads post `.mdx` files via `fs` (`ensurePostsDir()` → `fs.mkdirSync` → `EPERM`), which only works at **build** time, not at request time.
- Pages prerendered at build (when fs works) are served from cache and are fine.
- The homepage was the one content page that rendered **dynamically** at request time, because it called `headers()` directly to read the CSP nonce and had no `generateStaticParams`. So it always hit the dead fs path.

## Fix

Drop the homepage's direct `headers()`/nonce read so it prerenders like the rest of the site. The nonce was redundant — CSP already carries `'unsafe-inline'` for scripts, and the only nonced element was an `application/ld+json` block, which is data and never executed, so removing it doesn't change the security posture.

## Verification

- Local workerd (`wrangler dev` over the OpenNext build): `/` now returns 200 with the real page; no `EPERM`.
- `/blog`, `/blog/[slug]`, category, tag, archive, daily-word, portfolio all still 200.
- `pnpm lint` clean, `pnpm test` 121/121 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)