### PR TITLE
Attach saucy.tech custom domains (p3-2 cutover)

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -10,6 +10,13 @@
     "directory": ".open-next/assets",
     "binding": "ASSETS"
   },
+  "routes": [
+    { "pattern": "saucy.tech", "custom_domain": true },
+    { "pattern": "www.saucy.tech", "custom_domain": true }
+  ],
+  // Keep the workers.dev preview alive alongside the custom domains.
+  "workers_dev": true,
+  "preview_urls": true,
   "services": [
     {
       "binding": "WORKER_SELF_REFERENCE",


### PR DESCRIPTION
## Why

Migration manual task p3-2: cut saucy.tech over from Vercel to the Cloudflare Worker.

## What

- `routes`: `saucy.tech` + `www.saucy.tech` as Worker custom domains (config record of what is now live).
- `workers_dev: true` + `preview_urls: true`: wrangler disables the workers.dev preview by default when routes exist; this keeps it alive.

## Cutover already executed + verified live

- Old Vercel records removed (apex A ×2, www CNAME); rollback = recreate `A 64.29.17.1` / `A 216.198.79.1` or `CNAME www → b439c8576dbd16ca.vercel-dns-017.com`.
- https://saucy.tech 200 (Cloudflare), www → apex 301, blog/RSS/btcusd/LNURL callback/invoice/subscribe all verified on the live domain.
- workers.dev preview restored (200).

🤖 Generated with [Claude Code](https://claude.com/claude-code)