### PR TITLE
chore: remove duplicated security headers from next.config

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -17,41 +17,8 @@ const nextConfig = {
       },
     ];
   },
-  async headers() {
-    return [
-      {
-        source: '/:path*',
-        headers: [
-          {
-            key: 'X-DNS-Prefetch-Control',
-            value: 'off',
-          },
-          {
-            key: 'X-XSS-Protection',
-            value: '0',
-          },
-          {
-            key: 'X-Frame-Options',
-            value: 'DENY',
-          },
-          {
-            key: 'X-Content-Type-Options',
-            value: 'nosniff',
-          },
-          {
-            key: 'Referrer-Policy',
-            value: 'strict-origin-when-cross-origin',
-          },
-          {
-            key: 'Permissions-Policy',
-            value: 'geolocation=(), microphone=(), camera=(), fullscreen=(self)',
-          },
-          // CSP is handled by src/middleware.ts with dynamic nonces
-          // Removing duplicate CSP header that conflicts with middleware
-        ],
-      },
-    ];
-  },
+  // Security headers (CSP, X-Frame-Options, etc.) are set by src/middleware.ts
+  // via getSecurityHeaders(); defining them here too doubled every header value.
   images: {
     remotePatterns: [],
     formats: ['image/avif', 'image/webp'],


### PR DESCRIPTION
Migration manual task **p4-3**.

`src/middleware.ts` (via `getSecurityHeaders`) already sets X-Frame-Options, Referrer-Policy, X-Content-Type-Options, X-XSS-Protection, X-DNS-Prefetch-Control, and Permissions-Policy. The `headers()` block in `next.config.js` duplicated all six, so production responses emitted doubled values (`x-frame-options: DENY, DENY`). Removed the block; middleware remains the single source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)