### PR TITLE
chore(portfolio): add Field Manual and Feed Eggs, reflect Cloudflare hosting

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ personal-site/
 - **Icons**: Heroicons
 - **Payments**: Lightning Network integration (Alby SDK / NWC)
 - **Testing**: Jest + React Testing Library, Playwright (E2E)
-- **Deployment**: Vercel
+- **Deployment**: Cloudflare Workers (OpenNext adapter)
 - **Linting**: ESLint 9 + Prettier (Husky + lint-staged pre-commit)
 
 ## Getting Started
@@ -105,7 +105,8 @@ Daily Word devotions are the primary content pipeline. The lifecycle:
 3. On merge to `main`, `.github/workflows/devotion-broadcast.yml` fires and
    sends the post to ConvertKit (the "The Daily Word" email list) using
    `KIT_API_KEY`.
-4. Vercel deploys the post to production.
+4. The post goes live with the next production deploy (Cloudflare Workers via
+   OpenNext, `pnpm deploy`).
 
 Writing rules and quality checks for published content live in the scripts and
 runbooks in [`docs/`](./docs).
@@ -254,9 +255,14 @@ Operational runbooks:
 
 ## Deployment
 
-The easiest way to deploy your app is to use the [Vercel Platform](https://vercel.com/new).
+The site deploys to Cloudflare Workers via the
+[OpenNext Cloudflare adapter](https://opennext.js.org/cloudflare):
 
-Ensure all environment variables are configured in your deployment platform.
+```bash
+pnpm deploy   # opennextjs-cloudflare build + deploy (keeps existing Worker vars)
+```
+
+Ensure all environment variables and secrets are configured on the Worker.
 
 ## License
 

--- a/src/app/portfolio/page.tsx
+++ b/src/app/portfolio/page.tsx
@@ -49,7 +49,7 @@ export const metadata: Metadata = {
   },
 };
 
-const GROUP_ORDER: ProjectGroup[] = ['apps', 'tools', 'open-source', 'track-record'];
+const GROUP_ORDER: ProjectGroup[] = ['apps', 'tools', 'open-source', 'client-work', 'track-record'];
 
 const STATUS_PILL: Record<ProjectStatus, { label: string; className: string }> = {
   launched: { label: 'Launched', className: 'bg-green-500/80 text-white' },

--- a/src/data/portfolio-about.ts
+++ b/src/data/portfolio-about.ts
@@ -3,7 +3,7 @@
  * Bump `portfolioAboutLastUpdated` when revised.
  */
 
-export const portfolioAboutLastUpdated = '2026-05-21';
+export const portfolioAboutLastUpdated = '2026-06-12';
 
 export const portfolioAbout = {
   headline: 'Brandon Sauceda',

--- a/src/data/projects.ts
+++ b/src/data/projects.ts
@@ -5,7 +5,7 @@
 
 export const projectsLastUpdated = '2026-06-12';
 
-export type ProjectGroup = 'apps' | 'tools' | 'open-source' | 'track-record';
+export type ProjectGroup = 'apps' | 'tools' | 'open-source' | 'client-work' | 'track-record';
 
 export type ProjectStatus = 'launched' | 'contributor';
 
@@ -158,6 +158,18 @@ export const projects: Project[] = [
     links: [{ href: 'https://github.com/plebnet-dev/website', label: 'GitHub Repo' }],
   },
 
+  // --- Client Work ---
+  {
+    id: 'lawncare-site',
+    group: 'client-work',
+    title: 'Lawn Care Site',
+    status: 'launched',
+    tags: ['Next.js', 'TypeScript', 'Tailwind CSS', 'Cloudflare Workers'],
+    blurb:
+      'A sample client build: conversion-focused marketing site for a local lawn mowing business. Quote-request lead capture, bill pay through hosted Stripe checkout, LocalBusiness SEO schema, and one config file for all business details. Deployed on Cloudflare Workers.',
+    links: [{ href: 'https://lawncare-site.brandonsauceda.workers.dev', label: 'Live Demo' }],
+  },
+
   // --- Track Record ---
   {
     id: 'gda-public-systems',
@@ -209,5 +221,6 @@ export const projectGroupLabels: Record<ProjectGroup, string> = {
   apps: 'Products',
   tools: 'Tools',
   'open-source': 'Open Source Contributions',
+  'client-work': 'Client Work',
   'track-record': 'Track Record',
 };

--- a/src/data/projects.ts
+++ b/src/data/projects.ts
@@ -3,7 +3,7 @@
  * Edit here to update copy. Bump `projectsLastUpdated` when you revise.
  */
 
-export const projectsLastUpdated = '2026-05-22';
+export const projectsLastUpdated = '2026-06-12';
 
 export type ProjectGroup = 'apps' | 'tools' | 'open-source' | 'track-record';
 
@@ -60,6 +60,19 @@ export const projects: Project[] = [
     ],
   },
   {
+    id: 'feed-eggs',
+    group: 'apps',
+    title: 'Feed Eggs',
+    status: 'launched',
+    tags: ['Vanilla JS', 'Browser game', 'Cloudflare Workers'],
+    blurb:
+      'A browser arcade game: pull back a slingshot and fling eggs at a moving egg-mouth target. Vanilla JavaScript with no framework and no build step. Streak multipliers, levels that speed up the target, a rare golden egg worth 5x, and synthesized WebAudio sound. Served as static assets on Cloudflare Workers.',
+    links: [
+      { href: 'https://github.com/saucy-tech/eggman', label: 'GitHub Repo' },
+      { href: 'https://eggman.brandonsauceda.workers.dev', label: 'Live Demo' },
+    ],
+  },
+  {
     id: 'lightning-tip-jar',
     group: 'apps',
     title: 'Lightning Tip Jar',
@@ -77,9 +90,9 @@ export const projects: Project[] = [
     group: 'apps',
     title: 'This Portfolio Site',
     status: 'launched',
-    tags: ['Next.js', 'React', 'Tailwind CSS', 'MDX', 'Lightning'],
+    tags: ['Next.js', 'React', 'Tailwind CSS', 'MDX', 'Lightning', 'Cloudflare Workers'],
     blurb:
-      'Built with Next.js (App Router), React, and Tailwind CSS, integrating @getalby/sdk Nostr Wallet Connect for native Lightning payments. Custom MDX blog, responsive design, dark mode, subtle animations. All content and components managed locally, no external CMS.',
+      'Built with Next.js (App Router), React, and Tailwind CSS, integrating @getalby/sdk Nostr Wallet Connect for native Lightning payments. Custom MDX blog, responsive design, dark mode, subtle animations. Runs on Cloudflare Workers via the OpenNext adapter. All content and components managed locally, no external CMS.',
     links: [
       { href: 'https://github.com/saucy-tech/personal-site', label: 'GitHub Repo' },
       { href: '/support#lightning-tip-jar', label: 'Try Lightning Tip Jar' },
@@ -87,6 +100,16 @@ export const projects: Project[] = [
   },
 
   // --- Tools ---
+  {
+    id: 'field-manual',
+    group: 'tools',
+    title: 'Field Manual',
+    status: 'launched',
+    tags: ['Claude Code', 'AI agents', 'Open Source'],
+    blurb:
+      'An open-source Claude Code skill that turns a project into a single HTML file that acts as your UI for the agent: researched decision sections, an owner-badged task board, copy-prompt chips for delegating any task to a fresh session, and a status-sync loop so you and the agent share state through one file. No server, no database, no extension.',
+    links: [{ href: 'https://github.com/saucy-tech/field-manual', label: 'GitHub Repo' }],
+  },
   {
     id: 'work-time-visualizer',
     group: 'tools',


### PR DESCRIPTION
## What

- **Field Manual** added under Tools: open-source Claude Code skill ([saucy-tech/field-manual](https://github.com/saucy-tech/field-manual)) — single-file HTML UI for a coding agent.
- **Feed Eggs** added under Products: browser arcade game ([saucy-tech/eggman](https://github.com/saucy-tech/eggman)) with live demo at https://eggman.brandonsauceda.workers.dev.
- **This Portfolio Site** entry now notes Cloudflare Workers (OpenNext) hosting; added a Cloudflare Workers tag.
- **Client Work** section added (new `client-work` group between Open Source and Track Record) with the lawn care sample build — live demo at https://lawncare-site.brandonsauceda.workers.dev (repo is private, so the card links to the demo only).
- **README**: deployment references updated from Vercel to Cloudflare Workers (`pnpm deploy`).
- Bumped `projectsLastUpdated` and `portfolioAboutLastUpdated` to 2026-06-12 (drives the visible "Portfolio updated" line and JSON-LD `dateModified`).

## Intentionally not changed

- **Morning Portion entry still says Vercel** — morningportion.com is still served by Vercel; the Cloudflare worker is staged but DNS cutover is planned for later. Update the entry when that lands.
- **Roll to Eat demo link** — roll-to-eat.vercel.app still returns 200, left as-is.
- **README "CSP on Vercel" section** — left alone on purpose; the CSP env-detection code it documents needs a code fix first (tracked separately: production CSP currently includes `unsafe-eval` because `security.ts` still detects the Vercel env).

## Verification

- `pnpm quality:gate` passes (lint, tests, content validate, links, images, security drift). Remaining warnings are pre-existing (orphan posts, large legacy images).
- Dev server: /portfolio server-renders both new cards in order (Products: Morning Portion, Roll to Eat, Feed Eggs, Lightning Tip Jar, This Portfolio Site; Tools: Field Manual, Work Time Visualizer), links resolve, console clean, updated date shows 2026-06-12.
- Live URL check: eggman.brandonsauceda.workers.dev returns 200 from Cloudflare.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
