### PR TITLE
fix(security): serve strict production CSP on Cloudflare Workers

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,28 +269,34 @@ This project is licensed under the MIT License - see the LICENSE file for detail
 - Built with the Next.js framework
 - Lightning Network integration via Alby SDK
 
-## CSP on Vercel: Production-compatible configuration
+## Content Security Policy (Cloudflare Workers)
 
-This project uses a Content Security Policy (CSP) applied via Next.js [proxy](https://nextjs.org/docs/app/api-reference/file-conventions/proxy) (formerly middleware) to work consistently in both local development and Vercel production/preview deployments.
+The CSP is applied per-request by Next.js middleware so it behaves the same in
+local development and on Cloudflare Workers (OpenNext) in production.
 
 Key files:
 
-- [src/proxy.ts](src/proxy.ts)
-- [src/utils/security.ts](src/utils/security.ts)
-- [next.config.js](next.config.js)
+- [src/middleware.ts](src/middleware.ts) - generates a nonce and applies the headers
+- [src/utils/security.ts](src/utils/security.ts) - `getSecurityHeaders()` builds the policy
+- [scripts/check-security-drift.ts](scripts/check-security-drift.ts) - validates the production policy in `pnpm quality:gate`
+- [next.config.js](next.config.js) - non-CSP fallback headers and `poweredByHeader: false`
 
-What was fixed:
+Environment behavior:
 
-- Environment-aware CSP: production on Vercel vs local development are handled explicitly in [src/utils/security.ts](src/utils/security.ts).
-- Canvas-safe directives: allows 2D canvas animations and blobs for the animated galaxy background.
-- Worker allowances: permits blob/data workers sometimes needed for canvas ops.
-- Removed unsafe-eval in production, retained only where needed in development.
-- Removed X-Powered-By in Next.js config to avoid leaking server info via [next.config.js](next.config.js).
+- The policy branches on `NODE_ENV`, not on hosting-platform env vars. `next dev`
+  (`NODE_ENV=development`) allows `'unsafe-eval'` for HMR/React Refresh; every
+  other environment - production builds, the Worker runtime, anything
+  unrecognized - fails closed to the strict policy.
+- The strict policy drops `'unsafe-eval'` and adds `upgrade-insecure-requests`.
+- History: the original gate keyed on `VERCEL`/`VERCEL_ENV`, which do not exist
+  on Cloudflare Workers, so production served the development policy after the
+  migration (caught 2026-06-12). Platform-specific env detection is the failure
+  mode to avoid here.
 
 Effective CSP highlights (production):
 
 - default-src 'self'
-- script-src 'self' 'unsafe-inline' blob: (no 'unsafe-eval' in production)
+- script-src 'self' 'unsafe-inline' 'nonce-…' blob: (no 'unsafe-eval')
 - style-src 'self' 'unsafe-inline' data:
 - img-src 'self' data: blob: https: (required for canvas pixel operations and assets)
 - media-src 'self' data: blob:
@@ -300,56 +306,42 @@ Effective CSP highlights (production):
 - font-src 'self' data: https:
 - object-src 'none', frame-src 'none', frame-ancestors 'none'
 - base-uri 'self', form-action 'self'
-- upgrade-insecure-requests (production only)
+- upgrade-insecure-requests
 
-Why proxy (not meta tags):
+Drift enforcement:
 
-- Vercel's edge/runtime headers are stricter than local; setting CSP at the edge ensures consistent behavior across environments.
-- Proxy allows environment-aware CSP that differs between dev and production.
+- `pnpm security:drift` builds the headers with the production branch forced and
+  fails if `'unsafe-eval'` appears or `upgrade-insecure-requests` is missing,
+  alongside the baseline directive checks. It runs as part of `pnpm quality:gate`.
+- `src/utils/security.test.ts` pins both branches: development keeps eval,
+  production and unset environments do not.
 
 Verification steps:
 
-1. Local: verify headers
-   - curl -I http://localhost:3000
-   - Confirm presence of:
-     - content-security-policy header
-     - img-src includes data:, blob:, https:
-     - worker-src and child-src include blob: data:
-     - In development only: script-src includes 'unsafe-eval'
-2. Vercel preview/prod:
-   - Deploy to Vercel (preview)
-   - Open devtools Network tab on first load (not client-side navigated page)
-   - Check Response Headers on the document:
-     - content-security-policy is present (no duplicates)
-     - script-src has no 'unsafe-eval' in prod
-     - img-src has data: blob: https:
-     - worker-src/child-src allow blob: data:
-   - Confirm the animated galaxy background renders immediately on first load and interactive UI works.
+1. Local dev: `curl -I http://localhost:3000`
+   - content-security-policy present; script-src includes 'unsafe-eval' (dev only)
+2. Worker preview: `pnpm preview`, then `curl -I http://localhost:8787`
+   - script-src has no 'unsafe-eval'; upgrade-insecure-requests present
+3. Production: `curl -sI https://saucy.tech | grep -i content-security-policy`
+   - same strict policy as the preview
 
 Operational notes:
 
-- Do not add another CSP header via next.config.js; CSP is centralized in [src/proxy.ts](src/proxy.ts) using [src/utils/security.ts](src/utils/security.ts).
-- Avoid adding meta http-equiv="Content-Security-Policy" tags; headers beat meta and Vercel may enforce more strictly.
-- If adding new external APIs or CDNs, extend connect-src, font-src, img-src, etc., explicitly in [src/utils/security.ts](src/utils/security.ts).
-- If adding WebAssembly or specialized workers, ensure script-src and worker-src account for those needs without broadening to unsafe directives in production.
+- Do not add another CSP header via next.config.js or meta tags; CSP is
+  centralized in [src/middleware.ts](src/middleware.ts) using
+  [src/utils/security.ts](src/utils/security.ts).
+- If adding new external APIs or CDNs, extend connect-src, font-src, img-src,
+  etc., explicitly in [src/utils/security.ts](src/utils/security.ts).
+- If adding WebAssembly or specialized workers, ensure script-src and worker-src
+  account for those needs without broadening to unsafe directives in production.
 
 Troubleshooting:
 
-- If the galaxy canvas is blank only on first navigation in Vercel:
-  - Ensure the page load (not client-routed) response has the CSP header with the directives above.
-  - Check that no second CSP header is present (duplicates can override each other). Keep CSP only in proxy.
-- If fonts or images fail in Vercel but work locally, verify the corresponding src directives (font-src/img-src) include https: and data:/blob: as applicable.
-- If you see blocked scripts in production, verify that no 'unsafe-eval' is required.
-
-Security posture:
-
-- Production avoids 'unsafe-eval' (removed).
-- Uses 'unsafe-inline' for scripts/styles (required for Next.js compatibility).
-- No frames or objects allowed.
-- Permissions-Policy is set with conservative defaults in next.config.js headers; CSP and related security headers are set in proxy.
-
-Change log (CSP):
-
-- Centralized and hardened CSP in [src/utils/security.ts](src/utils/security.ts)
-- Ensured environment-aware behavior for Vercel deployments
-- Set poweredByHeader: false in [next.config.js](next.config.js) to remove X-Powered-By
+- If the galaxy canvas is blank on first load, check the document response has
+  the CSP header above and that no second CSP header is present (duplicates can
+  override each other). Keep CSP only in middleware.
+- If fonts or images fail in production but work locally, verify the
+  corresponding src directives (font-src/img-src) include https: and
+  data:/blob: as applicable.
+- If scripts are blocked in production, fix the script rather than reintroducing
+  'unsafe-eval'.

--- a/scripts/check-security-drift.ts
+++ b/scripts/check-security-drift.ts
@@ -1,11 +1,21 @@
 import { getSecurityHeaders, getSecurityHeaderDriftIssues } from '../src/utils/security';
 
 function main(): void {
+  // getSecurityHeaders() branches on NODE_ENV: development allows 'unsafe-eval'
+  // for HMR, everything else must get the strict production policy. Force the
+  // production branch so this check validates what deployed environments serve.
+  // (The Vercel->Cloudflare migration shipped the development policy to
+  // production; the old check missed it because it only looked at directives
+  // that are identical in both branches.)
+  (process.env as Record<string, string | undefined>).NODE_ENV = 'production';
+
   const headers = getSecurityHeaders();
-  const issues = getSecurityHeaderDriftIssues(headers);
+  const issues = getSecurityHeaderDriftIssues(headers, { expectProductionPolicy: true });
 
   if (issues.length === 0) {
-    console.log('Security drift check passed: required headers and CSP directives are present.');
+    console.log(
+      'Security drift check passed: required headers and production CSP directives are present.'
+    );
     return;
   }
 

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,7 +1,7 @@
 type LogLevel = 'info' | 'warn' | 'error';
 
 /**
- * Single-line JSON logs for Vercel log drains / grep-friendly monitoring.
+ * Single-line JSON logs for Cloudflare Workers Logs (`wrangler tail`) / grep-friendly monitoring.
  */
 export function logStructured(
   level: LogLevel,

--- a/src/utils/security.test.ts
+++ b/src/utils/security.test.ts
@@ -7,6 +7,7 @@ import {
   SECURITY_CONSTANTS,
   parseJsonBody,
   getSecurityHeaders,
+  getSecurityHeaderDriftIssues,
   assertSecurityHeadersHaveRequiredDirectives,
 } from '@/utils/security';
 import { NextRequest } from 'next/server';
@@ -389,6 +390,52 @@ describe('getSecurityHeaders', () => {
     expect(() => assertSecurityHeadersHaveRequiredDirectives(driftedHeaders)).toThrow(
       /security drift detected/i
     );
+  });
+});
+
+describe('getSecurityHeaders environment policy', () => {
+  const originalNodeEnv = process.env.NODE_ENV;
+
+  function setNodeEnv(value: string | undefined): void {
+    const env = process.env as Record<string, string | undefined>;
+    if (value === undefined) {
+      delete env.NODE_ENV;
+    } else {
+      env.NODE_ENV = value;
+    }
+  }
+
+  afterEach(() => {
+    setNodeEnv(originalNodeEnv);
+  });
+
+  it('serves the strict policy in production: no unsafe-eval, upgrades insecure requests', () => {
+    setNodeEnv('production');
+    const csp = getSecurityHeaders({ nonce: 'testnonce' })['Content-Security-Policy'];
+    expect(csp).not.toContain("'unsafe-eval'");
+    expect(csp).toContain('upgrade-insecure-requests');
+  });
+
+  it('allows unsafe-eval in development for HMR', () => {
+    setNodeEnv('development');
+    const csp = getSecurityHeaders({ nonce: 'testnonce' })['Content-Security-Policy'];
+    expect(csp).toContain("'unsafe-eval'");
+  });
+
+  it('fails closed to the strict policy when NODE_ENV is unset', () => {
+    setNodeEnv(undefined);
+    const csp = getSecurityHeaders({ nonce: 'testnonce' })['Content-Security-Policy'];
+    expect(csp).not.toContain("'unsafe-eval'");
+    expect(csp).toContain('upgrade-insecure-requests');
+  });
+
+  it('drift check rejects the development policy when production policy is expected', () => {
+    setNodeEnv('development');
+    const devHeaders = getSecurityHeaders({ nonce: 'testnonce' });
+    const issues = getSecurityHeaderDriftIssues(devHeaders, { expectProductionPolicy: true });
+
+    expect(issues.some((issue) => issue.includes("'unsafe-eval'"))).toBe(true);
+    expect(issues.some((issue) => issue.includes('upgrade-insecure-requests'))).toBe(true);
   });
 });
 

--- a/src/utils/security.ts
+++ b/src/utils/security.ts
@@ -339,7 +339,16 @@ const REQUIRED_CSP_SUBSTRINGS = [
   "form-action 'self'",
 ] as const;
 
-export function getSecurityHeaderDriftIssues(headers: Record<string, string>): string[] {
+// The CSP branches on environment (development allows 'unsafe-eval' for HMR).
+// These pins define what the production branch must and must not serve, so the
+// drift check fails if a deployed environment ever gets the development policy.
+const PRODUCTION_REQUIRED_CSP_SUBSTRINGS = ['upgrade-insecure-requests'] as const;
+const PRODUCTION_FORBIDDEN_CSP_SUBSTRINGS = ["'unsafe-eval'"] as const;
+
+export function getSecurityHeaderDriftIssues(
+  headers: Record<string, string>,
+  options: { expectProductionPolicy?: boolean } = {}
+): string[] {
   const issues: string[] = [];
 
   for (const headerName of REQUIRED_SECURITY_HEADERS) {
@@ -359,6 +368,20 @@ export function getSecurityHeaderDriftIssues(headers: Record<string, string>): s
     }
   }
 
+  if (options.expectProductionPolicy) {
+    for (const requiredPart of PRODUCTION_REQUIRED_CSP_SUBSTRINGS) {
+      if (!csp.includes(requiredPart)) {
+        issues.push(`Production CSP is missing required directive: ${requiredPart}`);
+      }
+    }
+
+    for (const forbiddenPart of PRODUCTION_FORBIDDEN_CSP_SUBSTRINGS) {
+      if (csp.includes(forbiddenPart)) {
+        issues.push(`Production CSP must not include: ${forbiddenPart}`);
+      }
+    }
+  }
+
   return issues;
 }
 
@@ -371,15 +394,16 @@ export function assertSecurityHeadersHaveRequiredDirectives(headers: Record<stri
 
 /**
  * Security headers configuration with production canvas support
- * Optimized for Vercel deployment environment
+ * Platform-neutral: behaves the same on Cloudflare Workers (OpenNext), Node, and `next dev`
  */
 export function getSecurityHeaders(options: { nonce?: string } = {}): Record<string, string> {
   const { nonce } = options;
-  // Detect Vercel environment
-  const isVercel = process.env.VERCEL === '1';
-  const vercelEnv = process.env.VERCEL_ENV;
-  const isVercelProduction =
-    isVercel && (vercelEnv === 'production' || process.env.NODE_ENV === 'production');
+  // Loosen the CSP only for `next dev` (NODE_ENV=development), which needs
+  // 'unsafe-eval' for HMR/React Refresh. Everything else - including unset or
+  // unrecognized environments - fails closed to the strict production policy.
+  // (Detection used to key on Vercel env vars, which never exist on Cloudflare
+  // Workers, so production served the development policy after the migration.)
+  const isDevelopment = process.env.NODE_ENV === 'development';
   const headers: Record<string, string> = {
     // Prevent DNS prefetching for privacy
     'X-DNS-Prefetch-Control': 'off',
@@ -402,7 +426,7 @@ export function getSecurityHeaders(options: { nonce?: string } = {}): Record<str
     // Remove server information
     'X-Powered-By': '',
 
-    // Minimal, widely-supported Permissions-Policy (avoid unrecognized features on Vercel/browsers)
+    // Minimal, widely-supported Permissions-Policy (avoid features browsers do not recognize)
     'Permissions-Policy': [
       'geolocation=()',
       'microphone=()',
@@ -416,11 +440,11 @@ export function getSecurityHeaders(options: { nonce?: string } = {}): Record<str
     "default-src 'self'",
 
     // Script sources: 'unsafe-inline' is required for Next.js App Router chunks/scripts that
-    // do not receive per-request nonces from proxy. Nonce remains for tagged inline scripts.
-    // eval only in non-production (Vercel preview local dev / non-prod NODE_ENV).
-    isVercelProduction
-      ? `script-src 'self' 'unsafe-inline'${nonce ? ` 'nonce-${nonce}'` : ''} blob:`
-      : `script-src 'self' 'unsafe-inline'${nonce ? ` 'nonce-${nonce}'` : ''} 'unsafe-eval' blob:`,
+    // do not receive per-request nonces from middleware. Nonce remains for tagged inline scripts.
+    // eval only in local development (HMR/React Refresh).
+    isDevelopment
+      ? `script-src 'self' 'unsafe-inline'${nonce ? ` 'nonce-${nonce}'` : ''} 'unsafe-eval' blob:`
+      : `script-src 'self' 'unsafe-inline'${nonce ? ` 'nonce-${nonce}'` : ''} blob:`,
     // Element-specific sources to satisfy browsers that split elem vs attr policies
     `script-src-elem 'self' 'unsafe-inline'${nonce ? ` 'nonce-${nonce}'` : ''} blob:`,
 
@@ -456,8 +480,8 @@ export function getSecurityHeaders(options: { nonce?: string } = {}): Record<str
     "form-action 'self'",
     "frame-ancestors 'none'",
 
-    // Upgrade insecure requests in production
-    ...(isVercelProduction ? ['upgrade-insecure-requests'] : []),
+    // Upgrade insecure requests everywhere except local development
+    ...(isDevelopment ? [] : ['upgrade-insecure-requests']),
   ];
 
   if (process.env.ENABLE_CSP_VIOLATION_REPORTS === '1') {


### PR DESCRIPTION
## Problem

Production has been serving the development CSP since the Cloudflare migration (#246). Verified 2026-06-12:

```
curl -sI https://saucy.tech | grep -i content-security-policy
# script-src 'self' 'unsafe-inline' 'nonce-…' 'unsafe-eval' blob:
```

`getSecurityHeaders()` gated the strict policy on `process.env.VERCEL === '1'`, which never exists on Cloudflare Workers, so `isVercelProduction` was always false: `'unsafe-eval'` shipped in `script-src` and `upgrade-insecure-requests` was missing. `pnpm security:drift` passed throughout because it only checked directives that are identical in both branches.

## Fix

- Gate on `NODE_ENV`, failing closed: only `next dev` (`NODE_ENV=development`) gets the `'unsafe-eval'` HMR allowance; production builds, the Worker runtime, and unrecognized/unset environments get the strict policy with `upgrade-insecure-requests`.
- `scripts/check-security-drift.ts` now forces the production branch and fails if `'unsafe-eval'` appears or `upgrade-insecure-requests` is missing — written first and confirmed to reproduce this exact regression before the fix.
- New tests pin both branches (production strict, development keeps eval, unset fails closed).
- Stale Vercel references updated: `security.ts` comments, `logger.ts` log-drain comment, README CSP section rewritten for the Cloudflare setup (also fixes its broken `src/proxy.ts` links → `src/middleware.ts`).

## Verification

- `pnpm quality:gate` passes; `tsc --noEmit` clean.
- `opennextjs-cloudflare preview` + `curl -I localhost:8787`: strict policy served — no `'unsafe-eval'`, `upgrade-insecure-requests` present, nonce + HSTS intact.
- Chromium console sweep over `/`, `/blog`, a post page, `/portfolio` on the preview: zero CSP violations.
- Playwright smoke vs preview: 5/7 pass — the same 2 fail against live production today (stale `<article>`/subscribe selectors + an RSC render error on post pages), so they are pre-existing and unrelated to CSP.

Not deployed — `pnpm deploy` pending go-ahead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)