### PR TITLE
fix: dedupe broken pnpm-lock.yaml (@types/node@25.9.3)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2283,9 +2283,6 @@ packages:
   '@types/node@25.9.3':
     resolution: {integrity: sha512-603BddQMv3pUcr4U2dhujk83N2tTDVr/34wII2B6bJy6g+8WD6yUb11jszNs0gdi4PesVWl7ABt8nYMVpnLUcg==}
 
-  '@types/node@25.9.3':
-    resolution: {integrity: sha512-603BddQMv3pUcr4U2dhujk83N2tTDVr/34wII2B6bJy6g+8WD6yUb11jszNs0gdi4PesVWl7ABt8nYMVpnLUcg==}
-
   '@types/react-dom@19.2.3':
     resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
     peerDependencies:
@@ -8262,10 +8259,6 @@ snapshots:
   '@types/node@18.19.130':
     dependencies:
       undici-types: 5.26.5
-
-  '@types/node@25.9.3':
-    dependencies:
-      undici-types: 7.24.6
 
   '@types/node@25.9.3':
     dependencies:


### PR DESCRIPTION
## Problem
[Run 27703825899](https://github.com/saucy-tech/personal-site/actions/runs/27703825899) failed at **Install dependencies**:

```
ERR_PNPM_BROKEN_LOCKFILE  The lockfile is broken: duplicated mapping key (2286:3)
```

PR #259 (dependabot minor-and-patch bump) left **two identical `@types/node@25.9.3` blocks** in `pnpm-lock.yaml` — once in the resolution map, once in snapshots. `pnpm install --frozen-lockfile` refuses a broken lockfile, so build/lint/test never ran.

## Fix
Removed the duplicate blocks only (−7 lines). No transitive version drift — a full `pnpm install` regen would have bumped ~hundreds of unrelated patch versions, which this avoids.

## Verification
`pnpm install --frozen-lockfile` now passes locally (pnpm 10.15.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)