### PR TITLE
chore: remove dead exported utility functions (~77 LOC)

### DIFF
--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -5,14 +5,6 @@ export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
 
-export function formatDate(date: Date): string {
-  return new Intl.DateTimeFormat('en-US', {
-    year: 'numeric',
-    month: 'long',
-    day: 'numeric',
-  }).format(date);
-}
-
 export function formatPostDate(date: string): string {
   const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(date.trim());
   if (!match) {

--- a/src/utils/lnurl-config.ts
+++ b/src/utils/lnurl-config.ts
@@ -47,47 +47,6 @@ export function validateLnurlAmount(amountMsats: number): { valid: boolean; erro
   return { valid: true };
 }
 
-// Validate LNURL comment with security measures
-export function validateLnurlComment(comment: string | null | undefined): {
-  valid: boolean;
-  sanitized?: string;
-  error?: string;
-} {
-  if (!comment) {
-    return { valid: true, sanitized: '' };
-  }
-
-  if (typeof comment !== 'string') {
-    return { valid: false, error: 'Comment must be a string.' };
-  }
-
-  // Remove null bytes and control characters except newlines and tabs
-  const sanitized = comment.replace(/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/g, '').trim();
-
-  if (sanitized.length > LNURL_CONFIG.commentAllowed) {
-    return {
-      valid: false,
-      error: `Comment too long (max: ${LNURL_CONFIG.commentAllowed} characters).`,
-    };
-  }
-
-  // Check for suspicious patterns (basic XSS prevention)
-  const suspiciousPatterns = [
-    /<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi,
-    /javascript:/gi,
-    /on\w+\s*=/gi,
-    /data:text\/html/gi,
-  ];
-
-  for (const pattern of suspiciousPatterns) {
-    if (pattern.test(sanitized)) {
-      return { valid: false, error: 'Comment contains suspicious content.' };
-    }
-  }
-
-  return { valid: true, sanitized };
-}
-
 // Session tracking for payment security
 const paymentSessions = new Map<
   string,
@@ -143,9 +102,4 @@ export function trackPaymentAttempt(paymentHash: string, amount: number, ip?: st
   }
 
   return true;
-}
-
-// Get payment session info for monitoring
-export function getPaymentSession(paymentHash: string) {
-  return paymentSessions.get(paymentHash);
 }

--- a/src/utils/nwc-client.ts
+++ b/src/utils/nwc-client.ts
@@ -14,9 +14,3 @@ export function getOrCreateNWCClient(nostrWalletConnectUrl: string): NWCClient {
   cachedUrl = nostrWalletConnectUrl;
   return cached;
 }
-
-/** Test helper: clear singleton between jest.resetModules() lifecycles if needed */
-export function resetNWCClientCacheForTests(): void {
-  cached = null;
-  cachedUrl = null;
-}

--- a/src/utils/posts.ts
+++ b/src/utils/posts.ts
@@ -183,19 +183,6 @@ export function getPostsByYearMonth(year: number, month: number): PostMeta[] {
   return getAllPostsMeta().filter((post) => post.date.startsWith(prefix));
 }
 
-/** `getAllPostsMeta()` is newest-first; older = next index, newer = previous index. */
-export function getAdjacentPosts(slug: string): { older: PostMeta | null; newer: PostMeta | null } {
-  const posts = getAllPostsMeta();
-  const idx = posts.findIndex((post) => post.slug === slug);
-  if (idx === -1) {
-    return { older: null, newer: null };
-  }
-  return {
-    older: posts[idx + 1] ?? null,
-    newer: posts[idx - 1] ?? null,
-  };
-}
-
 /** Same-series neighbors in chronological reading order (oldest → newest). */
 export function getAllYearMonthArchiveParams(): { year: string; month: string }[] {
   const keys = new Set<string>();
@@ -246,10 +233,6 @@ export function getReadingTimeFromContent(content: string): number {
     .trim();
   const wordCount = plainText ? plainText.split(' ').length : 0;
   return Math.max(1, Math.ceil(wordCount / WORDS_PER_MINUTE));
-}
-
-export function getPostSlugs(): string[] {
-  return getParsedPosts().map((entry) => entry.slug);
 }
 
 function getParsedPosts(): ParsedPostEntry[] {


### PR DESCRIPTION
## What

Ponytail audit — removes exported functions with **zero callers** in `src/` or `scripts/` and no test references.

| File | Removed | Note |
|---|---|---|
| `helpers.ts` | `formatDate` | pages use `formatPostDate` instead |
| `lnurl-config.ts` | `validateLnurlComment`, `getPaymentSession` | lnurlp callback uses `validateLnurlAmount` + `trackPaymentAttempt`; these were never called |
| `posts.ts` | `getAdjacentPosts`, `getPostSlugs` | no route/component references them |
| `nwc-client.ts` | `resetNWCClientCacheForTests` | test helper no test uses |

Kept everything still in use (e.g. `trackPaymentAttempt` and the `paymentSessions` map it relies on). **~77 LOC, no behavior change.**

## Verification

`pnpm lint`, `pnpm exec tsc --noEmit`, `pnpm test` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)