### PR TITLE
fix: disarm devotion broadcast label trigger, guard invoice route

### DIFF
--- a/.github/workflows/devotion-broadcast.yml
+++ b/.github/workflows/devotion-broadcast.yml
@@ -1,33 +1,32 @@
 name: Devotion Broadcast
 
-# Triggers when a PR with the "devotion" label is merged into main.
-# Can also be triggered manually via workflow_dispatch with a post slug.
+# Manual dispatch only. Devotion authoring moved to the-morning-portion repo;
+# the PR-label trigger was removed 2026-06-10 so a stray "devotion" label can
+# never email subscribers from this archive. Requires typing SEND to confirm.
 
 on:
-  pull_request:
-    types: [closed]
-    branches: [main]
   workflow_dispatch:
     inputs:
       slug:
         description: 'Post slug (e.g. 2026-03-18-the-word-that-mattered-most)'
         required: true
         type: string
+      confirm:
+        description: 'Type SEND to confirm emailing all Kit subscribers'
+        required: true
+        type: string
+
+concurrency:
+  group: devotion-broadcast
+  cancel-in-progress: false
 
 jobs:
   broadcast:
     name: Send Kit Broadcast
-    # On PR: only run when merged with the "devotion" label.
-    # On manual dispatch: always run.
-    if: >
-      github.event_name == 'workflow_dispatch' ||
-      (github.event.pull_request.merged == true &&
-       contains(github.event.pull_request.labels.*.name, 'devotion'))
+    if: github.event.inputs.confirm == 'SEND'
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      issues: write
-      pull-requests: write
 
     steps:
       - name: Checkout
@@ -35,34 +34,17 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Find new devotion post
+      - name: Find devotion post
         id: post
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            NEW_FILE="src/posts/${{ inputs.slug }}.mdx"
-            if [ ! -f "$NEW_FILE" ]; then
-              echo "::error::Post file not found: $NEW_FILE"
-              echo "skip=true" >> "$GITHUB_OUTPUT"
-            else
-              echo "file=$NEW_FILE" >> "$GITHUB_OUTPUT"
-              echo "skip=false" >> "$GITHUB_OUTPUT"
-              echo "Found post: $NEW_FILE"
-            fi
+          NEW_FILE="src/posts/${{ inputs.slug }}.mdx"
+          if [ ! -f "$NEW_FILE" ]; then
+            echo "::error::Post file not found: $NEW_FILE"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
           else
-            BASE="${{ github.event.pull_request.base.sha }}"
-            HEAD="${{ github.event.pull_request.merge_commit_sha }}"
-            echo "Checking diff: $BASE → $HEAD"
-
-            NEW_FILE=$(git diff --name-only --diff-filter=A "$BASE" "$HEAD" -- 'src/posts/*.mdx' | sort -r | head -1)
-
-            if [ -z "$NEW_FILE" ]; then
-              echo "No new MDX post found in this PR — skipping broadcast."
-              echo "skip=true" >> "$GITHUB_OUTPUT"
-            else
-              echo "file=$NEW_FILE" >> "$GITHUB_OUTPUT"
-              echo "skip=false" >> "$GITHUB_OUTPUT"
-              echo "Found post: $NEW_FILE"
-            fi
+            echo "file=$NEW_FILE" >> "$GITHUB_OUTPUT"
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+            echo "Found post: $NEW_FILE"
           fi
 
       - name: Extract post metadata
@@ -330,27 +312,3 @@ jobs:
             echo "post_url=${POST_URL}"
           } >> "$GITHUB_OUTPUT"
           echo "✓ Broadcast created (ID: ${BROADCAST_ID:-unknown}), scheduled for $SEND_AT"
-
-      - name: Comment on PR
-        if: steps.post.outputs.skip == 'false' && github.event_name == 'pull_request'
-        continue-on-error: true
-        env:
-          GH_TOKEN: ${{ github.token }}
-          POST_URL: ${{ steps.send_broadcast.outputs.post_url }}
-          BROADCAST_ID: ${{ steps.send_broadcast.outputs.broadcast_id }}
-        run: |
-          COMMENT_BODY=$(cat <<EOF
-          **The Daily Word broadcast sent!**
-
-          Post URL: ${POST_URL}
-          Broadcast ID: ${BROADCAST_ID:-unknown}
-
-          The broadcast has been scheduled to send to all Daily Word subscribers via Kit.
-          EOF
-          )
-
-          if gh pr comment ${{ github.event.pull_request.number }} --body "$COMMENT_BODY"; then
-            echo "Posted PR comment for broadcast ${BROADCAST_ID:-unknown}."
-          else
-            echo "::warning::Failed to post PR comment for broadcast ${BROADCAST_ID:-unknown}. The broadcast succeeded and the workflow will continue."
-          fi

--- a/README.md
+++ b/README.md
@@ -96,23 +96,26 @@ pandoc v2_Concise_ATS.md --standalone --css resume.css --metadata pagetitle='Bra
 
 ## Daily Devotion Workflow
 
-Daily Word devotions are the primary content pipeline. The lifecycle:
+New Daily Word devotions are authored in the `the-morning-portion` repo. The
+`src/posts/` directory here is an **archive** — leave it as-is unless explicitly
+asked to edit. The lifecycle for a post that ships from this repo:
 
 1. Brandon drafts the lesson in his Sunday School Obsidian vault.
-2. The `the-daily-word` Cowork skill reads today's entry, generates an MDX post
-   under `src/posts/YYYY-MM-DD-slug.mdx`, and opens a draft PR on this repo
-   labeled `devotion`.
-3. On merge to `main`, `.github/workflows/devotion-broadcast.yml` fires and
-   sends the post to ConvertKit (the "The Daily Word" email list) using
-   `KIT_API_KEY`.
-4. The merge is deployed to production automatically by Cloudflare Workers
-   Builds (Git integration).
+2. The authoring skill generates an MDX post under
+   `src/posts/YYYY-MM-DD-slug.mdx` and opens a PR.
+3. On merge to `main`, the post is deployed to production automatically by
+   Cloudflare Workers Builds (Git integration). **Merging does not send any
+   email** — the PR-label broadcast trigger was removed on 2026-06-10 so a stray
+   `devotion` label can never email subscribers from this archive.
+4. The ConvertKit email ("The Daily Word" list) is sent only by manually running
+   `.github/workflows/devotion-broadcast.yml` (Actions → Run workflow): supply
+   the post `slug` and type `SEND` in the confirm field. It uses `KIT_API_KEY`.
 
 Writing rules and quality checks for published content live in the scripts and
 runbooks in [`docs/`](./docs).
 
-`pnpm broadcast` is retained as a **manual fallback only** and is not the
-primary publishing path.
+`pnpm broadcast` is a second manual fallback that creates a draft broadcast from
+the latest post by frontmatter date.
 
 ## Contributing
 
@@ -164,11 +167,11 @@ SENTRY_DSN=
 
 ### GitHub Actions Secrets
 
-The devotion broadcast workflow is the primary production path. Configure these in **GitHub → Settings → Secrets and variables → Actions**:
+The devotion broadcast workflow runs only on manual dispatch (see Daily Devotion Workflow above). Configure these in **GitHub → Settings → Secrets and variables → Actions**:
 
 | Name | Type | Required by | Description |
 |------|------|-------------|-------------|
-| `KIT_API_KEY` | Secret | `devotion-broadcast.yml` | ConvertKit API key for the merge-based broadcast workflow |
+| `KIT_API_KEY` | Secret | `devotion-broadcast.yml` | ConvertKit API key for the manual broadcast workflow |
 | `NEXT_PUBLIC_APP_URL` | Variable | `devotion-broadcast.yml` | Your production site URL |
 
 `pnpm broadcast` is retained as a manual fallback. It creates a draft broadcast from the latest post by frontmatter date and should not be treated as the primary publishing path.

--- a/scripts/auto-broadcast.ts
+++ b/scripts/auto-broadcast.ts
@@ -157,6 +157,7 @@ async function main() {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(body),
+      signal: AbortSignal.timeout(30_000),
     }
   );
 

--- a/src/app/api/invoice/route.ts
+++ b/src/app/api/invoice/route.ts
@@ -89,6 +89,11 @@ export async function POST(request: NextRequest) {
         description: memoValidation.sanitized || 'Lightning Tip Jar',
       });
 
+      if (!result?.invoice || !result.payment_hash) {
+        console.error('Nostr Wallet Connect makeInvoice returned no invoice');
+        return createSecureErrorResponse('Unable to process payment request', 503);
+      }
+
       const paymentRequest = result.invoice;
       const paymentHash = result.payment_hash;
 


### PR DESCRIPTION
## What

Salvaged from the stale `fix/disarm-devotion-broadcast` branch (closed PR #245) — relanded by cherry-picking Brandon's original commit `ea2d158` cleanly onto current `main`. Of the three abandoned WIP branches, this is the only one whose change is **still missing from main**; the other two (`kit-v4-subscribe`, `worktree-p2-4-og-strip`) already landed and were deleted.

### Why it matters
`.github/workflows/devotion-broadcast.yml` on `main` **still fires on a merged PR carrying the `devotion` label** and emails the entire Kit subscriber list. Devotion authoring moved to `saucy-tech/the-morning-portion`, so in this archive repo that trigger is pure latent liability — a single mislabeled merge mass-emails subscribers. (CLAUDE.md already flags this as a known hazard.)

### Changes (3 files, +26/−62)
- **devotion-broadcast.yml** — remove the `pull_request: [closed]` trigger entirely → **manual `workflow_dispatch` only**, now requiring a `confirm: SEND` input (`if: github.event.inputs.confirm == 'SEND'`). Adds a `concurrency` group so re-runs can't overlap, tightens `permissions` to `contents: read`, and drops the now-dead PR-diff discovery + PR-comment steps.
- **scripts/auto-broadcast.ts** — 30s `AbortSignal.timeout` on the manual broadcast's Kit API call.
- **src/app/api/invoice/route.ts** — null guard on the NWC `makeInvoice` result: a missing invoice returns `503` instead of throwing.

## Verification
`pnpm lint`, `pnpm exec tsc --noEmit`, `pnpm test` all green. Workflow change is verified to remove the `pull_request` trigger (manual dispatch path preserved).

**Draft** — outward-facing email-broadcast workflow; opening for your review rather than self-merging. Do NOT add the `devotion` label to this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)