### PR TITLE
feat(support): add private Trump Account request

### DIFF
--- a/docs/implementation-notes/pr-272-revision.md
+++ b/docs/implementation-notes/pr-272-revision.md
@@ -1,0 +1,37 @@
+# Implementation Notes — PR 272 Revision
+
+**Spec:** Conversation approving the support-only revision of https://github.com/saucy-tech/personal-site/pull/272
+**Started:** 2026-07-13
+**Status:** complete
+
+## How to read this file
+
+Running log of decisions, deviations, and tradeoffs made while implementing the spec. Entries are append-only and chronological. Each entry names the spec section it relates to so you can diff intent vs. shipped code.
+
+## Decisions not covered by the spec
+
+### Rewrite the existing PR from `main` — 2026-07-13
+**Spec section:** Better PR structure
+PR 272 is being rebuilt as a support-only change instead of retaining the abandoned domain-split commits. A local backup branch preserves the previous head, and the remote update will use force-with-lease so unexpected remote changes cannot be overwritten.
+
+### Use email as the private handoff — 2026-07-13
+**Spec section:** Keep the Trump Account change separate
+The page will offer a pre-addressed email action rather than publishing another contribution URL or relying on vague “message me” copy. This uses the same public contact address already shown throughout the site and gives visitors a concrete next step.
+
+### Match the existing family-savings language — 2026-07-13
+**Spec section:** Keep the Trump Account change separate
+The new heading will use “My Son” rather than adding the child’s name to the public page. This matches the adjacent 529 section, keeps the presentation restrained, and avoids publishing an unnecessary personal identifier.
+
+## Deviations from the spec
+
+## Tradeoffs accepted
+
+### The exposed contribution link still requires external rotation — 2026-07-13
+**Spec section:** Keep the Trump Account change separate
+Rewriting the PR removes the secret-bearing commit from the active branch history, but it cannot revoke a link already published in GitHub commit and review history. Rotation must happen through the contribution provider and remains an owner follow-up.
+
+## Surprises and gotchas
+
+## Open questions for review
+
+- Confirm that the previously exposed contribution link has been rotated or invalidated before merging.

--- a/src/app/support/page.tsx
+++ b/src/app/support/page.tsx
@@ -69,6 +69,22 @@ export default async function Support({ searchParams }: SupportPageProps) {
           </div>
         </div>
       </Section>
+
+      <Section emoji="🏦" title={"Gift to My Son's Trump Account"}>
+        <div className="w-full max-w-md mx-auto p-6">
+          <div className="border border-(--accent-border) rounded-lg p-6">
+            <p className="text-(--text-secondary) mb-4">
+              Family and friends can email me for the private contribution link.
+            </p>
+            <a
+              href="mailto:brandon@saucy.tech?subject=Trump%20Account%20contribution%20link"
+              className="inline-block rounded-sm bg-(--accent) px-4 py-2 text-sm font-medium text-(--on-accent) transition hover:bg-(--accent-dark)"
+            >
+              Request the contribution link
+            </a>
+          </div>
+        </div>
+      </Section>
     </PageLayout>
   );
 }


### PR DESCRIPTION
## Summary

- Adds a neutral Trump Account contribution option to `/support` alongside the existing Lightning and 529 options.
- Keeps the private contribution URL off the public site and provides a clear email action for family and friends to request it.
- Removes the abandoned Saucy Tech landing page, `/brandon` route, sitemap entry, and domain-split runbook so this PR has one focused purpose.

## Why

The previous version mixed a small support-page addition with a much larger and premature brand/domain split. This revision keeps `saucy.tech` as Brandon's unified personal and business site and limits the PR to the contribution flow it originally set out to add.

## Security follow-up

The original contribution link appeared in an earlier public commit and review history. Rewriting this branch removes it from the active PR diff, but the old link should still be rotated or invalidated before merge.

## Test plan

- `pnpm check` — lint, TypeScript, and 19 suites / 127 tests passed
- `pnpm quality:gate` — passed; existing archive content/link/image warnings remain unchanged
- `pnpm build` — Next.js production build succeeded

## Implementation notes

- Decisions and the remaining rotation follow-up are captured in `docs/implementation-notes/pr-272-revision.md`.
