### PR TITLE
refine homepage product hierarchy

### DIFF
--- a/docs/implementation-notes/homepage-professional-refresh.md
+++ b/docs/implementation-notes/homepage-professional-refresh.md
@@ -1,0 +1,39 @@
+# Implementation Notes — Homepage Professional Refresh
+
+**Spec:** Conversation request on 2026-07-13 to make the homepage more professional, feature The Morning Portion as the flagship product, and stop presenting the migrated Daily Word archive as the latest post
+**Started:** 2026-07-13
+**Status:** complete
+
+## How to read this file
+
+Running log of decisions, deviations, and tradeoffs made while implementing the spec. Entries are append-only and chronological. Each entry names the spec section it relates to so you can diff intent vs. shipped code.
+
+## Decisions not covered by the spec
+
+### Keep the homepage refresh separate from PR 272 — 2026-07-13
+**Spec section:** Professional homepage
+The support-page change remains a focused PR. This homepage work will ship as a separate draft PR so the editorial and navigation decisions can be reviewed independently.
+
+### Remove the automated latest-post card for now — 2026-07-13
+**Spec section:** Latest post
+The current newest local posts are Daily Word entries that now belong to The Morning Portion. The homepage will keep a general Writing destination but will not label an archived entry as the latest post until new personal-site writing resumes.
+
+### Preserve the existing visual system — 2026-07-13
+**Spec section:** Professional homepage
+This is a hierarchy and copy refinement, not a visual redesign. The existing profile, social bar, LinkCard, Section, color themes, and narrow layout remain in place while the content order and wording become more focused.
+
+### Reuse the official Morning Portion mark — 2026-07-13
+**Spec section:** Flagship product
+The flagship card will use the existing Morning Portion icon from the product repository rather than an emoji or newly invented artwork. This makes the product visually distinct while keeping its established brand intact.
+
+## Deviations from the spec
+
+## Tradeoffs accepted
+
+### No new article is part of this change — 2026-07-13
+**Spec section:** Latest post
+The user noted that a new post probably needs to be written but did not request article creation in this pass. The homepage will avoid stale recency claims without inventing or rushing new editorial content.
+
+## Surprises and gotchas
+
+## Open questions for review

--- a/public/icons/morning-portion.svg
+++ b/public/icons/morning-portion.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" rx="10" fill="#FBF7ED"/>
+  <path d="M18 20 A14 14 0 0 1 46 20" fill="none" stroke="#B8842D" stroke-width="4" stroke-linecap="round"/>
+  <path d="M10 28 H28 C30.6 28 32 30.2 32 34 C32 30.2 33.4 28 36 28 H54" fill="none" stroke="#64705C" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M12 32 C20 29.4 27 29.6 32 34 C37 29.6 44 29.4 52 32 V54 C44 50.8 37 51.1 32 56 C27 51.1 20 50.8 12 54 Z" fill="none" stroke="#0B2633" stroke-width="3" stroke-linejoin="round"/>
+  <path d="M32 34 V56" stroke="#0B2633" stroke-width="3"/>
+</svg>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -7,10 +7,10 @@ import Profile from '@/components/Profile';
 import Section from '@/components/Section';
 import SocialBar from '@/components/SocialBar';
 import SubscribeForm from '@/components/SubscribeForm';
-import { formatPostDate } from '@/utils/helpers';
-import { getAllPostsMeta } from '@/utils/posts';
 
 export const metadata: Metadata = {
+  description:
+    'Brandon Sauceda is a software engineer, independent builder, and creator of The Morning Portion.',
   alternates: {
     canonical: '/',
   },
@@ -19,7 +19,7 @@ export const metadata: Metadata = {
   },
 };
 
-export default async function Home() {
+export default function Home() {
   const profileData = {
     name: 'Brandon',
     bio: 'Love Jesus, Explore Ideas, Create Things, Save in Bitcoin',
@@ -81,39 +81,49 @@ export default async function Home() {
     },
   ];
 
-  const posts = getAllPostsMeta();
-  const latest = posts[0];
-
   return (
     <div className="pt-4 pb-6 px-4 md:px-8 flex flex-col items-center">
       <div className="space-y-6 w-full max-w-lg mx-auto">
         <div className="space-y-2">
           <Profile {...profileData} />
           <p className="text-center text-sm leading-relaxed text-(--text-secondary)">
-            Independent developer. My own products, plus a few client projects a year.
+            Software engineer. I build my own products and take on a few client projects each year.
           </p>
         </div>
         <SocialBar socials={socialLinks} />
 
         <div className="space-y-3">
-          {latest && (
-            <LinkCard
-              key="latest-blog"
-              title={latest.title}
-              cardTitle={latest.cardTitle}
-              href={`/blog/${latest.slug}`}
-              icon={<span className="text-2xl">📝</span>}
-              eyebrow="Latest Post"
-              meta={[latest.categoryLabel, formatPostDate(latest.date)].join(' • ')}
-            />
-          )}
+          <LinkCard
+            key="morning-portion"
+            title="The Morning Portion"
+            href="https://morningportion.com"
+            imageSrc="/icons/morning-portion.svg"
+            eyebrow="Flagship product"
+            meta="Weekday scripture reflections, published at morningportion.com"
+          />
+          <LinkCard
+            key="my-projects"
+            title="Projects"
+            href="/portfolio"
+            icon={<span className="text-2xl">🚀</span>}
+            eyebrow="Selected work"
+            meta="Products, public-sector systems, open source, and résumé"
+          />
+          <LinkCard
+            key="work-with-me"
+            title="Client work"
+            href="/about#work-with-me"
+            icon={<span className="text-2xl">🤝</span>}
+            eyebrow="Client work"
+            meta="Web apps and focused product builds"
+          />
           <LinkCard
             key="blog-home"
             title="Writing"
             href="/blog"
             icon={<span className="text-2xl">📚</span>}
-            eyebrow="Blog"
-            meta={`${posts.length} posts`}
+            eyebrow="Essays & archive"
+            meta="Personal essays and the earlier Daily Word archive"
           />
           <LinkCard
             key="field-notes"
@@ -122,22 +132,6 @@ export default async function Home() {
             icon={<span className="text-2xl">📓</span>}
             eyebrow="Field notes"
             meta="Tools, tech, and gear I'm using now"
-          />
-          <LinkCard
-            key="my-projects"
-            title="Projects"
-            href="/portfolio"
-            icon={<span className="text-2xl">🚀</span>}
-            eyebrow="Projects"
-            meta="Products, track record, talks, and résumé"
-          />
-          <LinkCard
-            key="work-with-me"
-            title="Client work"
-            href="/about#work-with-me"
-            icon={<span className="text-2xl">🤝</span>}
-            eyebrow="Client work"
-            meta="A few projects a year"
           />
           <LinkCard
             key="bitcoin"
@@ -155,9 +149,9 @@ export default async function Home() {
             eyebrow="Faith"
             meta="Truth Chapel livestreams and teaching"
           />
-          <Section title="Subscribe to Saucy.tech Updates" emoji="✉️">
+          <Section title="Subscribe to Saucy.Tech">
             <p className="text-sm leading-relaxed text-(--text-secondary)">
-              New essays, field notes, and writing, straight to your inbox.
+              Occasional notes on software, tools, and current projects.
             </p>
             <SubscribeForm />
           </Section>


### PR DESCRIPTION
## Summary

- Positions The Morning Portion as Brandon's flagship product and gives it the first homepage card with its official brand mark.
- Reorders the homepage around products, selected work, and client work before writing, field notes, and personal links.
- Removes the automated latest-post card now that the newest local entries are part of the migrated Daily Word archive.
- Tightens the introduction, project descriptions, homepage metadata, and subscription language into a more professional register.

## Why

The homepage treated an archived Daily Word entry as current and gave Brandon's strongest product no meaningful prominence. The revised hierarchy reflects the actual work: The Morning Portion first, then the broader product and professional record, without overstating the business or filling the page with marketing language.

## User impact

Visitors get a clearer picture of Brandon's work immediately, The Morning Portion is recognizable as the flagship product, and the site no longer implies that a migrated archive entry is a recent personal post.

## Test plan

- `pnpm check` — lint, TypeScript, and 19 suites / 127 tests passed
- `pnpm quality:gate` — passed; existing archive content/link/image warnings remain unchanged
- `pnpm build` — Next.js production build succeeded

## Implementation notes

- Editorial decisions and tradeoffs are captured in `docs/implementation-notes/homepage-professional-refresh.md`.
