### PR TITLE
Add private Oura health policy pages

### DIFF
--- a/src/app/oura-health/layout.tsx
+++ b/src/app/oura-health/layout.tsx
@@ -1,0 +1,12 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  robots: {
+    index: false,
+    follow: true,
+  },
+};
+
+export default function OuraHealthLayout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/src/app/oura-health/page.tsx
+++ b/src/app/oura-health/page.tsx
@@ -18,7 +18,8 @@ export default function OuraHealthPage() {
         <section className="space-y-4">
           <p className="text-base leading-relaxed text-(--text-secondary)">
             Sunday Health Review is a private, single-user integration that Brandon Sauceda uses to
-            bring his Oura sleep and recovery data into a local weekly health review.
+            bring his Oura sleep, recovery, stress, and cardiovascular trends into a local weekly
+            health review.
           </p>
           <p className="text-base leading-relaxed text-(--text-secondary)">
             It is not a public product, does not accept accounts, and does not provide medical

--- a/src/app/oura-health/page.tsx
+++ b/src/app/oura-health/page.tsx
@@ -1,0 +1,57 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+
+import PageLayout from '@/components/PageLayout';
+
+export const metadata: Metadata = {
+  title: 'Sunday Health Review',
+  description: 'Information about Brandon Sauceda’s private Oura health-data integration.',
+  alternates: {
+    canonical: '/oura-health',
+  },
+};
+
+export default function OuraHealthPage() {
+  return (
+    <PageLayout title="Sunday Health Review">
+      <div className="mx-auto max-w-2xl space-y-8">
+        <section className="space-y-4">
+          <p className="text-base leading-relaxed text-(--text-secondary)">
+            Sunday Health Review is a private, single-user integration that Brandon Sauceda uses to
+            bring his Oura sleep and recovery data into a local weekly health review.
+          </p>
+          <p className="text-base leading-relaxed text-(--text-secondary)">
+            It is not a public product, does not accept accounts, and does not provide medical
+            advice. Oura data is processed for Brandon&apos;s personal use and is not sold or used
+            for advertising.
+          </p>
+        </section>
+
+        <section className="space-y-3 border-t border-(--accent-border) pt-6">
+          <h2 className="text-xl font-semibold">Policies</h2>
+          <div className="flex flex-col items-start gap-3">
+            <Link
+              href="/oura-health/privacy"
+              className="a11y-focus-ring rounded-xs text-(--accent) hover:underline"
+            >
+              Privacy Policy
+            </Link>
+            <Link
+              href="/oura-health/terms"
+              className="a11y-focus-ring rounded-xs text-(--accent) hover:underline"
+            >
+              Terms of Use
+            </Link>
+          </div>
+        </section>
+
+        <p className="text-sm text-(--text-secondary)">
+          Questions:{' '}
+          <a className="text-(--accent) hover:underline" href="mailto:brandon@saucy.tech">
+            brandon@saucy.tech
+          </a>
+        </p>
+      </div>
+    </PageLayout>
+  );
+}

--- a/src/app/oura-health/privacy/page.tsx
+++ b/src/app/oura-health/privacy/page.tsx
@@ -32,9 +32,9 @@ export default function OuraHealthPrivacyPage() {
         <section className="space-y-3">
           <h2 className="text-xl font-semibold">Data accessed</h2>
           <p className="leading-relaxed text-(--text-secondary)">
-            The integration requests Oura daily sleep, readiness, activity, recovery, and SpO2 data.
-            It does not request Oura email, profile, workout, tag, session, or ring configuration
-            data.
+            The integration requests Oura daily sleep, readiness, activity, recovery, SpO2, daytime
+            stress, resilience, cardiovascular age, and pulse-wave velocity data. It does not
+            request Oura email, profile, workout, tag, session, or ring configuration data.
           </p>
         </section>
 

--- a/src/app/oura-health/privacy/page.tsx
+++ b/src/app/oura-health/privacy/page.tsx
@@ -1,0 +1,81 @@
+import type { Metadata } from 'next';
+
+import PageLayout from '@/components/PageLayout';
+
+export const metadata: Metadata = {
+  title: 'Sunday Health Review Privacy Policy',
+  description: 'Privacy policy for Brandon Sauceda’s private Oura health-data integration.',
+  alternates: {
+    canonical: '/oura-health/privacy',
+  },
+};
+
+export default function OuraHealthPrivacyPage() {
+  return (
+    <PageLayout
+      title="Sunday Health Review Privacy Policy"
+      backHref="/oura-health"
+      backLabel="Back to Sunday Health Review"
+    >
+      <article className="mx-auto max-w-2xl space-y-8">
+        <p className="text-sm text-(--text-secondary)">Effective July 26, 2026</p>
+
+        <section className="space-y-3">
+          <h2 className="text-xl font-semibold">Purpose</h2>
+          <p className="leading-relaxed text-(--text-secondary)">
+            Sunday Health Review is a private integration used only by Brandon Sauceda. It imports
+            selected Oura data into Brandon&apos;s personal weekly health review. It has no public
+            users or account system.
+          </p>
+        </section>
+
+        <section className="space-y-3">
+          <h2 className="text-xl font-semibold">Data accessed</h2>
+          <p className="leading-relaxed text-(--text-secondary)">
+            The integration requests Oura daily sleep, readiness, activity, recovery, and SpO2 data.
+            It does not request Oura email, profile, workout, tag, session, or ring configuration
+            data.
+          </p>
+        </section>
+
+        <section className="space-y-3">
+          <h2 className="text-xl font-semibold">Storage and security</h2>
+          <p className="leading-relaxed text-(--text-secondary)">
+            Oura API credentials and refresh tokens are stored in the macOS Keychain. Imported data
+            is stored in Brandon&apos;s private local and iCloud health records. This public website
+            does not receive or store Oura health data.
+          </p>
+        </section>
+
+        <section className="space-y-3">
+          <h2 className="text-xl font-semibold">Sharing and use</h2>
+          <p className="leading-relaxed text-(--text-secondary)">
+            Oura data is used only for Brandon&apos;s personal health tracking. It is not sold,
+            licensed, used for advertising, or shared with other users. Apple may process stored
+            files through Brandon&apos;s private iCloud account under Apple&apos;s own terms.
+          </p>
+        </section>
+
+        <section className="space-y-3">
+          <h2 className="text-xl font-semibold">Retention and deletion</h2>
+          <p className="leading-relaxed text-(--text-secondary)">
+            Imported records are retained as part of Brandon&apos;s personal longitudinal health
+            history until he deletes them. Oura access can be revoked from the Oura account, and
+            locally stored credentials can be removed at any time.
+          </p>
+        </section>
+
+        <section className="space-y-3">
+          <h2 className="text-xl font-semibold">Contact</h2>
+          <p className="leading-relaxed text-(--text-secondary)">
+            Questions about this policy can be sent to{' '}
+            <a className="text-(--accent) hover:underline" href="mailto:brandon@saucy.tech">
+              brandon@saucy.tech
+            </a>
+            .
+          </p>
+        </section>
+      </article>
+    </PageLayout>
+  );
+}

--- a/src/app/oura-health/privacy/page.tsx
+++ b/src/app/oura-health/privacy/page.tsx
@@ -41,9 +41,10 @@ export default function OuraHealthPrivacyPage() {
         <section className="space-y-3">
           <h2 className="text-xl font-semibold">Storage and security</h2>
           <p className="leading-relaxed text-(--text-secondary)">
-            Oura API credentials and refresh tokens are stored in the macOS Keychain. Imported data
-            is stored in Brandon&apos;s private local and iCloud health records. This public website
-            does not receive or store Oura health data.
+            Oura API credentials and refresh tokens are stored in the macOS Keychain when available,
+            with an encrypted, owner-only local credential store used for unattended reliability.
+            Imported data is stored in Brandon&apos;s private local and iCloud health records. This
+            public website does not receive or store Oura health data.
           </p>
         </section>
 

--- a/src/app/oura-health/terms/page.tsx
+++ b/src/app/oura-health/terms/page.tsx
@@ -1,0 +1,78 @@
+import type { Metadata } from 'next';
+
+import PageLayout from '@/components/PageLayout';
+
+export const metadata: Metadata = {
+  title: 'Sunday Health Review Terms of Use',
+  description: 'Terms of use for Brandon Sauceda’s private Oura health-data integration.',
+  alternates: {
+    canonical: '/oura-health/terms',
+  },
+};
+
+export default function OuraHealthTermsPage() {
+  return (
+    <PageLayout
+      title="Sunday Health Review Terms of Use"
+      backHref="/oura-health"
+      backLabel="Back to Sunday Health Review"
+    >
+      <article className="mx-auto max-w-2xl space-y-8">
+        <p className="text-sm text-(--text-secondary)">Effective July 26, 2026</p>
+
+        <section className="space-y-3">
+          <h2 className="text-xl font-semibold">Personal use</h2>
+          <p className="leading-relaxed text-(--text-secondary)">
+            Sunday Health Review is a private tool operated by Brandon Sauceda for his own health
+            tracking. It is not offered as a public service and does not accept user accounts.
+          </p>
+        </section>
+
+        <section className="space-y-3">
+          <h2 className="text-xl font-semibold">No medical service</h2>
+          <p className="leading-relaxed text-(--text-secondary)">
+            The integration organizes personal data. It does not diagnose, treat, or prevent any
+            condition and is not a substitute for professional medical care.
+          </p>
+        </section>
+
+        <section className="space-y-3">
+          <h2 className="text-xl font-semibold">Availability and accuracy</h2>
+          <p className="leading-relaxed text-(--text-secondary)">
+            The integration is provided as-is for personal use. Data may be delayed, incomplete, or
+            unavailable because of device syncing, Oura service changes, network problems, or local
+            software errors. Health decisions should not rely on this integration alone.
+          </p>
+        </section>
+
+        <section className="space-y-3">
+          <h2 className="text-xl font-semibold">Third-party services</h2>
+          <p className="leading-relaxed text-(--text-secondary)">
+            The integration depends on Oura, Apple, and other local services, which operate under
+            their own terms and privacy policies. Oura is a trademark of Oura Health Oy. This
+            integration is not endorsed by or affiliated with Oura.
+          </p>
+        </section>
+
+        <section className="space-y-3">
+          <h2 className="text-xl font-semibold">Changes and termination</h2>
+          <p className="leading-relaxed text-(--text-secondary)">
+            Brandon may change or stop the integration at any time. Oura access may also be revoked
+            at any time through the connected Oura account.
+          </p>
+        </section>
+
+        <section className="space-y-3">
+          <h2 className="text-xl font-semibold">Contact</h2>
+          <p className="leading-relaxed text-(--text-secondary)">
+            Questions about these terms can be sent to{' '}
+            <a className="text-(--accent) hover:underline" href="mailto:brandon@saucy.tech">
+              brandon@saucy.tech
+            </a>
+            .
+          </p>
+        </section>
+      </article>
+    </PageLayout>
+  );
+}


### PR DESCRIPTION
## What changed

- adds a small public landing page for the private Sunday Health Review integration
- adds an Oura-specific privacy policy and terms of use
- keeps all three routes out of search indexes and site navigation

## Why

Oura’s developer portal requires public website, privacy-policy, and terms URLs before it will issue OAuth application credentials. These pages describe the actual single-user local integration without exposing health data or presenting it as a public product.

## Validation

- `pnpm check`
- `pnpm quality:gate`
- `pnpm build`
- local HTTP verification: all three routes returned 200 with the expected canonical URL and `noindex, follow` metadata