### PR TITLE
build(deps): bump brace-expansion@1 override to 1.1.18 (alert #78)

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
       "ajv@>=6.0.0 <6.14.0": ">=6.14.0",
       "flatted@<3.4.0": "3.4.2",
       "postcss@<8.5.10": ">=8.5.10",
-      "brace-expansion@1": "^1.1.17",
+      "brace-expansion@1": "^1.1.18",
       "brace-expansion@2": "^2.1.4",
       "brace-expansion@3": "^3.0.1",
       "brace-expansion@4": "^4.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,7 +18,7 @@ overrides:
   ajv@>=6.0.0 <6.14.0: '>=6.14.0'
   flatted@<3.4.0: 3.4.2
   postcss@<8.5.10: '>=8.5.10'
-  brace-expansion@1: ^1.1.17
+  brace-expansion@1: ^1.1.18
   brace-expansion@2: ^2.1.4
   brace-expansion@3: ^3.0.1
   brace-expansion@4: ^4.0.1
@@ -2808,8 +2808,8 @@ packages:
   bowser@2.14.1:
     resolution: {integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==}
 
-  brace-expansion@1.1.17:
-    resolution: {integrity: sha512-w+aeW/mkgM4PyRMOJCgi3fOrTm5Q8QY1OSfn2TO2iuDj3ezIHqejmuxbjfPrqUkgqRew1iqkyAn0tr0ZwHD9+w==}
+  brace-expansion@1.1.18:
+    resolution: {integrity: sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==}
 
   brace-expansion@2.1.4:
     resolution: {integrity: sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==}
@@ -8834,7 +8834,7 @@ snapshots:
 
   bowser@2.14.1: {}
 
-  brace-expansion@1.1.17:
+  brace-expansion@1.1.18:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
@@ -11292,7 +11292,7 @@ snapshots:
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.17
+      brace-expansion: 1.1.18
 
   minimatch@8.0.7:
     dependencies:


### PR DESCRIPTION
Closes the last remaining brace-expansion advisory. `pnpm audit` goes from 1 high to **no known vulnerabilities**.

## The fix
`brace-expansion@1` override was pinned at `^1.1.17`; advisory range is `<1.1.18` (DoS via unbounded intermediate arrays, bypassing the CVE-2026-14257 mitigation). Bumped to `^1.1.18`. Lockfile diff is limited to that one resolution.

## Why this one was invisible
Alert #78 was **auto-dismissed by GitHub**, not fixed, so it never showed up next to #72–#77 and #79 in the open list. The cause is the preset development-scope triage rule:

| | #77 | #78 |
| --- | --- | --- |
| package | brace-expansion | brace-expansion |
| CVSS | 7.5 | 7.5 |
| CWE | CWE-400 / CWE-770 | CWE-400 / CWE-770 |
| **scope** | **runtime** | **development** |
| outcome | stayed open | auto-dismissed |

Identical advisory, identical severity — the only difference is dependency scope. The rule is defensible (a DoS in build-time-only tooling isn't a real threat surface) and I'd leave it enabled, but it means `pnpm audit` and the GitHub alert list will disagree, and the disagreement is silent.

## Verification
- `pnpm audit` → no known vulnerabilities
- `pnpm quality:gate` passes (lint, 127 tests / 19 suites, content validate, internal links, image hygiene, security drift)
- `pnpm build` passes

## Note
Commit is unsigned — the signing key needs interactive Touch ID, unavailable from an automated session. `main` still gets a GitHub-signed commit via squash merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)