### PR TITLE
feat(portfolio): feature Sunday School, retire the self-referential site card

### DIFF
--- a/src/data/projects.ts
+++ b/src/data/projects.ts
@@ -19,7 +19,7 @@ export interface Project {
   group: ProjectGroup;
   title: string;
   status: ProjectStatus;
-  /** The two products I am actively building. Renders a Featured pill and sorts first. */
+  /** The products I actively build and use. Renders a Featured pill and sorts first. */
   featured?: boolean;
   tags: string[];
   blurb: string;
@@ -60,6 +60,22 @@ export const projects: Project[] = [
     ],
   },
   {
+    id: 'sunday-school',
+    group: 'apps',
+    title: 'Sunday School',
+    status: 'launched',
+    featured: true,
+    tags: ['Vanilla JS', 'PWA', 'Service worker', 'Offline-first', 'Cloudflare Workers'],
+    blurb:
+      'The lesson app I teach from on an iPad, in a classroom where the signal drops. A service worker precaches every lesson in the quarter, so the menu and the lesson open with no network at all; when that is not enough, any lesson or a whole quarter exports as one self-contained HTML file that opens from the Files app with no service worker involved. The menu, the lesson dates, and the badge on this Sunday are generated from the lesson files rather than hand-edited, so adding a lesson is dropping a file in a folder. No framework and no build step beyond a dependency-free Node script, covered by a test suite that runs on node --test. The lessons are written against paid curriculum and the real site sits behind Cloudflare Access, so what you can open here is a demo carrying three sample lessons written from scratch and none of the curriculum.',
+    links: [
+      {
+        href: 'https://sunday-school-demo.brandonsauceda.workers.dev',
+        label: 'Open the demo',
+      },
+    ],
+  },
+  {
     id: 'feed-eggs',
     group: 'apps',
     title: 'Feed Eggs',
@@ -83,19 +99,6 @@ export const projects: Project[] = [
     links: [
       { href: 'https://github.com/saucy-tech/lntipjar', label: 'GitHub Repo' },
       { href: '/support', label: 'Live Demo' },
-    ],
-  },
-  {
-    id: 'portfolio-site',
-    group: 'apps',
-    title: 'This Portfolio Site',
-    status: 'launched',
-    tags: ['Next.js', 'React', 'Tailwind CSS', 'MDX', 'Lightning', 'Cloudflare Workers'],
-    blurb:
-      'Built with Next.js (App Router), React, and Tailwind CSS, integrating @getalby/sdk Nostr Wallet Connect for native Lightning payments. Custom MDX blog, responsive design, dark mode, subtle animations. Runs on Cloudflare Workers via the OpenNext adapter. All content and components managed locally, no external CMS.',
-    links: [
-      { href: 'https://github.com/saucy-tech/personal-site', label: 'GitHub Repo' },
-      { href: '/support#lightning-tip-jar', label: 'Try Lightning Tip Jar' },
     ],
   },
 


### PR DESCRIPTION
Adds the Sunday School app to Products as a third Featured card, now that it has a demo worth linking: https://sunday-school-demo.brandonsauceda.workers.dev

Paired with saucy-tech/sunday-school-site#8, which builds and deploys that demo.

## Three featured cards, and why that still reads

The `featured` comment said *"the two products I am actively building."* It is three now. They are not three of the same thing:

| | |
| --- | --- |
| **The Morning Portion** | a publishing product — writing, broadcast, podcast |
| **Train Every Day** | a logger for the gym floor |
| **Sunday School** | a teaching app for a classroom with no signal |

Two of them are offline-first, which reads as a theme rather than repetition: both are for places where the network is not there, and both keep working anyway. The blurbs lean on that instead of hiding it.

## The card I removed

You asked whether something else could come out. **"This Portfolio Site."** It was the weakest card on the page:

- it describes the page the reader is already on
- its stack (Next.js, React, Tailwind, MDX, Cloudflare Workers) is restated by nearly every other card
- both its links survive elsewhere — the repo is public, and the Lightning Tip Jar has its own card and its own section on `/support`

This is the one judgment call in the PR and the easy one to reverse: drop the commit's second hunk and the card comes back, with the three Featured cards unaffected.

## Checks

`pnpm quality:gate` exit 0. `pnpm build` completes clean.

Draft per the repo convention — ready for your read and a codex pass.