### PR TITLE
Correct 2026 GMIS awards: G2G to international, add chapter G2B, fix G2C year

### DIFF
--- a/src/data/awards.ts
+++ b/src/data/awards.ts
@@ -6,7 +6,7 @@
  * Within scope: most recent year, then alphabetical by name.
  */
 
-export const awardsLastUpdated = '2026-08-11';
+export const awardsLastUpdated = '2026-08-24';
 
 export interface Award {
   id: string;
@@ -64,10 +64,18 @@ export const awards: Award[] = [
 
   // State / chapter scope
   {
+    id: 'gmis-g2b-ga',
+    name: 'Georgia GMIS G2B Award — Government to Business',
+    issuer: 'GMIS Georgia Chapter',
+    years: ['2026'],
+    impact:
+      'GMIS Georgia Chapter recognition for outstanding achievement in supporting business through innovative government solutions.',
+  },
+  {
     id: 'gmis-g2c',
     name: 'Georgia GMIS G2C Award — Government to Citizens',
     issuer: 'GMIS Georgia Chapter',
-    years: ['2026', '2025'],
+    years: ['2025'],
     impact:
       'GMIS Georgia Chapter recognition for software delivering public-facing services directly to Georgia citizens.',
   },

--- a/src/data/awards.ts
+++ b/src/data/awards.ts
@@ -6,7 +6,7 @@
  * Within scope: most recent year, then alphabetical by name.
  */
 
-export const awardsLastUpdated = '2026-05-07';
+export const awardsLastUpdated = '2026-08-11';
 
 export interface Award {
   id: string;
@@ -19,6 +19,14 @@ export interface Award {
 
 export const awards: Award[] = [
   // International scope
+  {
+    id: 'gmis-g2g',
+    name: 'GMIS G2G Award — Government to Government',
+    issuer: 'GMIS International + GMIS Georgia Chapter',
+    years: ['2026'],
+    impact:
+      'GMIS (Government Management Information Sciences) recognition for cross-agency software collaboration delivering services between governmental entities. Won at the Georgia Chapter level, then advanced to win internationally.',
+  },
   {
     id: 'legends-of-lightning-hackathon',
     name: 'Legends of Lightning Vol. 2 Hackathon Winner',
@@ -62,14 +70,6 @@ export const awards: Award[] = [
     years: ['2026', '2025'],
     impact:
       'GMIS Georgia Chapter recognition for software delivering public-facing services directly to Georgia citizens.',
-  },
-  {
-    id: 'gmis-g2g',
-    name: 'Georgia GMIS G2G Award — Government to Government',
-    issuer: 'GMIS Georgia Chapter',
-    years: ['2026'],
-    impact:
-      'GMIS Georgia Chapter recognition for cross-agency software collaboration delivering services between governmental entities.',
   },
   {
     id: 'gta-innovation-showcase',


### PR DESCRIPTION
Corrects the 2026 GMIS awards on `/portfolio`. Three changes, one file.

**1. G2G moves to international scope.** The 2026 G2G listed here was the Georgia Chapter win. GMIS International notified GDA on 2026-08-11 that the entry advanced and won at the international level, so it moves up into the international block and the issuer becomes `GMIS International + GMIS Georgia Chapter` — matching how the 2019 G2B is already cited.

**2. Adds the 2026 Georgia GMIS G2B award, which was never on the site.** GDA won two chapter awards in 2026, G2G and G2B. Only the G2G was listed.

**3. Drops the 2026 from the G2C line.** That year was never won. GDA's G2C win was 2025 (Commissioner Scheduling Portal), which is what [gagmis.org](https://www.gagmis.org/awards/previous-award-winners/) lists. The `['2026', '2025']` on that entry has been there unverified since `awards.ts` was first added in #196 — it looks like the 2026 G2B got recorded in the wrong category and the G2C year was carried forward with it.

Net effect on the rendered list:

| | before | after |
|---|---|---|
| GMIS G2G | 2026, chapter | 2026, **international + chapter** |
| Georgia GMIS G2B | — | **2026** (new) |
| Georgia GMIS G2C | 2026, 2025 | **2025** |

`awardsLastUpdated` bumped. Ordering follows the file's existing rule — international first, then within scope most-recent-year then alphabetical.

Verified against the physical trophies (both engraved *Georgia Department of Agriculture*, 2026) plus the chapter's published winners list.

`pnpm lint`, `tsc --noEmit`, and `pnpm test` all pass (20 suites, 133 tests).

> **Before merge:** both commits on this branch are unsigned and `main` requires signatures, so it shows `BLOCKED`. Collapse and sign from a machine with the signing key:
> ```
> git fetch origin && git checkout feat/gmis-2026-g2g-international
> git reset --soft origin/main
> git commit -S -m "correct 2026 GMIS awards on portfolio"
> git push --force-with-lease
> ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
