### PR TITLE
docs: add SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,20 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+Please don't open a public issue for a security problem. Report it privately instead:
+
+- **Preferred:** [Open a private advisory](https://github.com/saucy-tech/personal-site/security/advisories/new) — the thread stays attached to this repo.
+- **Email:** brandon@saucy.tech
+
+This is a personal project, so I can't promise a response time. I read every report and will tell you what I decide to do about it.
+
+## Scope
+
+The code in this repository and the site it deploys at [saucy.tech](https://saucy.tech).
+
+## Out of scope
+
+- Missing security headers or cookie flags on a static site that has no accounts, sessions, or user data.
+- Dependency CVEs with no demonstrated exploit path here — Dependabot already tracks those.
+- Automated scanner output submitted without a working proof of concept.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -13,8 +13,9 @@ This is a personal project, so I can't promise a response time. I read every rep
 
 The code in this repository and the site it deploys at [saucy.tech](https://saucy.tech).
 
+That includes the unauthenticated API routes under `/api` — subscriber signup, which forwards visitor email addresses to Kit, and Lightning invoice creation. Anything touching those is squarely in scope.
+
 ## Out of scope
 
-- Missing security headers or cookie flags on a static site that has no accounts, sessions, or user data.
 - Dependency CVEs with no demonstrated exploit path here — Dependabot already tracks those.
 - Automated scanner output submitted without a working proof of concept.


### PR DESCRIPTION
Adds a `SECURITY.md` so a stranger who finds a flaw has a private place to send it instead of opening a public issue.

GitHub surfaces this on the Security tab and in the new-issue chooser. It is a routing sign, not a control — no code changes.

- Points at private advisories first, email second
- States scope explicitly
- Makes no response-time promise

Replaces #295, which was blocked by the signed-commits rule: that commit was authored under a stale repo-local git identity so GitHub could not attribute the signature. The local override has been removed; this commit verifies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)