### PR TITLE
docs(field-notes): separate harnesses from interfaces and trim evaluating

### DIFF
--- a/src/app/field-notes/page.tsx
+++ b/src/app/field-notes/page.tsx
@@ -52,8 +52,11 @@ export default function FieldNotesPage() {
     <PageLayout title="Field notes" backHref="/" backLabel="Back to Home">
       <div className="max-w-2xl space-y-3">
         <p className="text-base leading-relaxed text-(--text-secondary)">
-          What I&rsquo;m into in tech right now — the tools I reach for and what I&rsquo;m still
-          evaluating. A snapshot, updated when it changes.
+          How I actually work with AI right now: pick a model, a harness to run it in, and an
+          interface to drive the harness from. The shift that matters is that AI coding is no longer
+          just chatting with a model — it is a loop: give context, let an agent inspect the repo,
+          make edits, run tests and checks, review the output, iterate. A snapshot, updated when it
+          changes.
         </p>
         <p className="text-sm text-(--text-secondary)">
           <span className="uppercase tracking-[0.14em] text-xs">

--- a/src/data/field-notes.ts
+++ b/src/data/field-notes.ts
@@ -1,11 +1,10 @@
 /**
  * Field notes (`/field-notes`) — how I actually work with AI right now.
  *
- * Sections are workflow-native rather than a flat tool ranking: orchestration
- * first (Current workflow), then the models, the harnesses that run them inside
- * a repo, the interfaces I drive those harnesses from, and what I'm still
- * evaluating — plus the subscriptions, infrastructure, and utilities
- * underneath. Harness = the agent loop (Claude Code, Codex, OpenCode);
+ * Sections follow the order the choice is actually made: the models, the
+ * harnesses that run them inside a repo, the interfaces I drive those harnesses
+ * from, and what I'm still evaluating — plus the subscriptions, infrastructure,
+ * and utilities underneath. Harness = the agent loop (Claude Code, Codex, OpenCode);
  * interface = the surface I sit in front of (T3 Code, Warp, the desktop apps).
  * The point is the loop, not the chat: give context, let an agent inspect the
  * repo, make edits, run tests/checks, review the output, iterate.
@@ -17,7 +16,6 @@
 export const fieldNotesLastUpdated = '2026-08-23';
 
 export type FieldNoteStatus =
-  | 'workflow'
   | 'coding-agents'
   | 'models'
   | 'interfaces'
@@ -26,7 +24,8 @@ export type FieldNoteStatus =
   | 'infrastructure'
   | 'tools';
 
-export type FieldNoteBadge = 'daily' | 'experimenting' | 'learning' | 'paused' | 'watching';
+export type FieldNoteBadge =
+  'daily' | 'occasional' | 'experimenting' | 'learning' | 'paused' | 'watching';
 
 export interface FieldNoteItem {
   title: string;
@@ -49,40 +48,9 @@ export interface FieldNoteSection {
 
 export const fieldNotesSections: FieldNoteSection[] = [
   {
-    id: 'workflow',
-    title: 'Current workflow',
-    blurb:
-      'How I actually work with AI right now: orchestration first, then a model, a harness to run it in, and an interface to drive the harness from. The shift that matters is that AI coding is no longer just chatting with a model — it is a loop: give context, let an agent inspect the repo, make edits, run tests and checks, review the output, iterate.',
-    items: [
-      {
-        title: 'Hermes Agent',
-        tags: ['nous research', 'orchestration', 'command center'],
-        badge: 'learning',
-        homepage: 'https://hermes-agent.nousresearch.com',
-        note: 'My orchestration layer and command center — Nous Research’s agent harness, self-hosted on the VPS. It coordinates Claude Code and Codex CLI as workers, exposes a dashboard, and takes work over a Telegram gateway, all over Tailscale rather than the public internet. This is where the loop starts: I hand it context and a goal, and it routes the actual repo work to a coding agent.',
-        pros: [
-          'One surface to dispatch and coordinate coding agents',
-          'Remote control from my phone via Telegram',
-          'Private by default — no public exposure',
-        ],
-        cons: ['Early days; I am still shaping how I lean on it day to day'],
-      },
-      {
-        title: 'M1 MacBook Pro',
-        tags: ['apple silicon', 'local environment', 'hardware'],
-        badge: 'daily',
-        homepage: 'https://www.apple.com',
-        note: 'The local environment everything runs against — not an AI tool, but the machine the agents edit and the checks run on. Still plenty of headroom for the whole stack of CLIs, editors, and a browser at once.',
-        pros: ['Handles the full local toolchain comfortably', 'Quiet, cool, and always ready'],
-        cons: ['Heavier model and container work still belongs on the VPS'],
-      },
-    ],
-  },
-  {
     id: 'models',
     title: 'Models',
-    blurb:
-      'The raw horsepower. Five models, pinned ⌘1–⌘5 in T3 Code, in the order I reach for them.',
+    blurb: 'The raw horsepower. Five models, pinned ⌘1–⌘5 in T3 Code.',
     items: [
       {
         title: 'Claude Fable 5',
@@ -143,7 +111,7 @@ export const fieldNotesSections: FieldNoteSection[] = [
         cons: ['I still pair it with Codex when I want a second read'],
       },
       {
-        title: 'Codex CLI',
+        title: 'Codex',
         tags: ['openai', 'cli', 'coding agent'],
         badge: 'daily',
         homepage: 'https://openai.com',
@@ -195,7 +163,7 @@ export const fieldNotesSections: FieldNoteSection[] = [
       {
         title: 'Claude desktop',
         tags: ['anthropic', 'desktop app'],
-        badge: 'learning',
+        badge: 'occasional',
         homepage: 'https://claude.ai',
         note: 'Mostly for chat — conversation and thinking out loud rather than repo edits, which stay in Claude Code. In the rotation, but a smaller share of my week than it used to be.',
         pros: ['Good for conversation and thinking out loud'],
@@ -204,7 +172,7 @@ export const fieldNotesSections: FieldNoteSection[] = [
       {
         title: 'Codex desktop',
         tags: ['openai', 'desktop app'],
-        badge: 'daily',
+        badge: 'occasional',
         homepage: 'https://openai.com',
         note: 'Where my scheduled tasks live. Recurring jobs run here on a timer while the interactive Codex work happens in T3 Code.',
         pros: ['Scheduled tasks without a server or cron to babysit'],
@@ -226,6 +194,18 @@ export const fieldNotesSections: FieldNoteSection[] = [
         note: "Warp's cloud-agent orchestration. Same family as my daily terminal, so I am testing where cloud agents fit next to Hermes and the local CLIs.",
         pros: ['Fits the Warp-centered direction of the stack'],
         cons: ['Still forming an opinion on when to reach for it'],
+      },
+      {
+        title: 'Hermes Agent',
+        tags: ['nous research', 'orchestration', 'command center'],
+        badge: 'experimenting',
+        homepage: 'https://hermes-agent.nousresearch.com',
+        note: 'Nous Research’s agent harness, self-hosted on the VPS. It can coordinate Claude Code and Codex as workers and take work over a Telegram gateway, all over Tailscale rather than the public internet. For me it is the remote and async lane — a job I can kick off from my phone — while most real work still happens locally on the Mac.',
+        pros: [
+          'Remote control from my phone via Telegram',
+          'Private by default — no public exposure',
+        ],
+        cons: ['Still deciding what actually belongs in a remote lane versus the local loop'],
       },
     ],
   },
@@ -276,8 +256,18 @@ export const fieldNotesSections: FieldNoteSection[] = [
   {
     id: 'infrastructure',
     title: 'Infrastructure',
-    blurb: 'Where my sites and services actually live — hosting, DNS, and the always-on box.',
+    blurb:
+      'Where the work and the sites actually live — the local box, the always-on box, hosting, and DNS.',
     items: [
+      {
+        title: 'M1 MacBook Pro',
+        tags: ['apple silicon', 'local environment', 'hardware'],
+        badge: 'daily',
+        homepage: 'https://www.apple.com',
+        note: 'Where the work actually happens. Not an AI tool, but the machine the harnesses edit on and the checks run against, and the default over the VPS for nearly everything. Still plenty of headroom for the whole stack of CLIs, editors, and a browser at once.',
+        pros: ['Handles the full local toolchain comfortably', 'Quiet, cool, and always ready'],
+        cons: ['Heavier model and container work still belongs on the VPS'],
+      },
       {
         title: 'Hostinger VPS',
         tags: ['hostinger', 'KVM 4', 'Ubuntu 24.04'],

--- a/src/data/field-notes.ts
+++ b/src/data/field-notes.ts
@@ -145,8 +145,8 @@ export const fieldNotesSections: FieldNoteSection[] = [
         homepage: 'https://t3.codes',
         note: 'Where I spend most of my time now. Not a harness — it sits on top of Claude Code, Codex, and OpenCode and lets me run any of them from one window, with five models pinned to ⌘1–⌘5 so switching is a keystroke instead of a context rebuild.',
         pros: [
-          'One harness over several coding agents',
-          'Switch models and agents without leaving the flow',
+          'One interface over three harnesses',
+          'Switch models and harnesses without leaving the flow',
         ],
         cons: ['Warp still wins when I just want a terminal'],
       },

--- a/src/data/field-notes.ts
+++ b/src/data/field-notes.ts
@@ -2,17 +2,19 @@
  * Field notes (`/field-notes`) — how I actually work with AI right now.
  *
  * Sections are workflow-native rather than a flat tool ranking: orchestration
- * first (Current workflow), then the coding agents that operate inside a repo,
- * the models I reach for, the interfaces I live in, and what I'm still
+ * first (Current workflow), then the models, the harnesses that run them inside
+ * a repo, the interfaces I drive those harnesses from, and what I'm still
  * evaluating — plus the subscriptions, infrastructure, and utilities
- * underneath. The point is the loop, not the chat: give context, let an agent
- * inspect the repo, make edits, run tests/checks, review the output, iterate.
+ * underneath. Harness = the agent loop (Claude Code, Codex, OpenCode);
+ * interface = the surface I sit in front of (T3 Code, Warp, the desktop apps).
+ * The point is the loop, not the chat: give context, let an agent inspect the
+ * repo, make edits, run tests/checks, review the output, iterate.
  *
  * Edit here to update copy; bump `fieldNotesLastUpdated` when you revise.
  */
 
 /** ISO date — bump when you revise items or copy. Shown on `/field-notes`. */
-export const fieldNotesLastUpdated = '2026-08-22';
+export const fieldNotesLastUpdated = '2026-08-23';
 
 export type FieldNoteStatus =
   | 'workflow'
@@ -50,7 +52,7 @@ export const fieldNotesSections: FieldNoteSection[] = [
     id: 'workflow',
     title: 'Current workflow',
     blurb:
-      'How I actually work with AI right now: orchestration first, coding agents second, models as interchangeable horsepower. The shift that matters is that AI coding is no longer just chatting with a model — it is a loop: give context, let an agent inspect the repo, make edits, run tests and checks, review the output, iterate.',
+      'How I actually work with AI right now: orchestration first, then a model, a harness to run it in, and an interface to drive the harness from. The shift that matters is that AI coding is no longer just chatting with a model — it is a loop: give context, let an agent inspect the repo, make edits, run tests and checks, review the output, iterate.',
     items: [
       {
         title: 'Hermes Agent',
@@ -77,46 +79,10 @@ export const fieldNotesSections: FieldNoteSection[] = [
     ],
   },
   {
-    id: 'coding-agents',
-    title: 'Coding agents & harnesses',
-    blurb: 'Tools that can operate inside a repo instead of just answering in chat.',
-    items: [
-      {
-        title: 'Claude Code',
-        tags: ['anthropic', 'cli', 'coding agent'],
-        badge: 'daily',
-        homepage: 'https://claude.ai',
-        note: 'My default coding agent for high-context, repo-shaped work — planning, larger edits, and longer sessions where keeping the whole repo in view matters.',
-        pros: ['Strong at planning and repo-shaped work', 'Holds context across longer sessions'],
-        cons: ['I still pair it with Codex when I want a second read'],
-      },
-      {
-        title: 'Codex CLI',
-        tags: ['openai', 'cli', 'coding agent'],
-        badge: 'daily',
-        homepage: 'https://openai.com',
-        note: 'My implementation-and-inspection agent: fast at reading the repo, making focused edits, and running the test/check loop. I drive it through T3 Code or Warp, often as a second read against Claude Code.',
-        pros: ['Quick into implementation and repo inspection', 'Clean inside T3 Code and Warp'],
-        cons: ['I reach for Claude Code first on the largest, most context-heavy tasks'],
-      },
-      {
-        title: 'T3 Code',
-        tags: ['agent harness', 'coding interface'],
-        badge: 'daily',
-        homepage: 'https://t3.codes',
-        note: 'Where I spend most of my time now. An agent harness, not just a wrapper — it drives Claude Code, Codex, and OpenCode from one interface, with five models pinned to ⌘1–⌘5 so switching is a keystroke instead of a context rebuild.',
-        pros: [
-          'One harness over several coding agents',
-          'Switch models and agents without leaving the flow',
-        ],
-        cons: ['Warp still wins when I just want a terminal'],
-      },
-    ],
-  },
-  {
     id: 'models',
     title: 'Models',
-    blurb: 'The five I keep pinned in T3 Code, in the order I reach for them.',
+    blurb:
+      'The raw horsepower. Five models, pinned ⌘1–⌘5 in T3 Code, in the order I reach for them.',
     items: [
       {
         title: 'Claude Fable 5',
@@ -162,10 +128,60 @@ export const fieldNotesSections: FieldNoteSection[] = [
     ],
   },
   {
+    id: 'coding-agents',
+    title: 'Harnesses',
+    blurb:
+      'The agent loop itself — the thing that takes a model, gives it tools, and lets it inspect a repo, edit, and run checks. Each harness is tied to a vendor’s models; the interface I drive it from is a separate choice.',
+    items: [
+      {
+        title: 'Claude Code',
+        tags: ['anthropic', 'cli', 'coding agent'],
+        badge: 'daily',
+        homepage: 'https://claude.ai',
+        note: 'My default harness for high-context, repo-shaped work — planning, larger edits, and longer sessions where keeping the whole repo in view matters. Runs the Claude models; I drive it from T3 Code or Warp.',
+        pros: ['Strong at planning and repo-shaped work', 'Holds context across longer sessions'],
+        cons: ['I still pair it with Codex when I want a second read'],
+      },
+      {
+        title: 'Codex CLI',
+        tags: ['openai', 'cli', 'coding agent'],
+        badge: 'daily',
+        homepage: 'https://openai.com',
+        note: 'My implementation-and-inspection agent: fast at reading the repo, making focused edits, and running the test/check loop. I drive it through T3 Code or Warp, often as a second read against Claude Code.',
+        pros: ['Quick into implementation and repo inspection', 'Clean inside T3 Code and Warp'],
+        cons: ['I reach for Claude Code first on the largest, most context-heavy tasks'],
+      },
+      {
+        title: 'OpenCode',
+        tags: ['open source', 'cli', 'coding agent'],
+        badge: 'experimenting',
+        homepage: 'https://opencode.ai',
+        note: 'The open-source harness, and the only one of the three that is not tied to a single vendor. I run it through T3 Code on the Go plan, mostly to put Kimi K3 into the same loop as the Claude and GPT models.',
+        pros: [
+          'Vendor-neutral — any model in the same loop',
+          'Same repo workflow as the other two',
+        ],
+        cons: ['Still deciding how much work it earns beyond Kimi'],
+      },
+    ],
+  },
+  {
     id: 'interfaces',
     title: 'Interfaces',
-    blurb: 'Where the work happens day to day.',
+    blurb: 'The surfaces I sit in front of. An interface hosts a harness; it does not replace one.',
     items: [
+      {
+        title: 'T3 Code',
+        tags: ['interface', 'multi-harness', 'daily driver'],
+        badge: 'daily',
+        homepage: 'https://t3.codes',
+        note: 'Where I spend most of my time now. Not a harness — it sits on top of Claude Code, Codex, and OpenCode and lets me run any of them from one window, with five models pinned to ⌘1–⌘5 so switching is a keystroke instead of a context rebuild.',
+        pros: [
+          'One harness over several coding agents',
+          'Switch models and agents without leaving the flow',
+        ],
+        cons: ['Warp still wins when I just want a terminal'],
+      },
       {
         title: 'Warp',
         tags: ['terminal', 'interface', 'daily driver'],
@@ -211,30 +227,6 @@ export const fieldNotesSections: FieldNoteSection[] = [
         pros: ['Fits the Warp-centered direction of the stack'],
         cons: ['Still forming an opinion on when to reach for it'],
       },
-      {
-        title: 'VS Code',
-        tags: ['microsoft', 'editor', 'agent mode'],
-        badge: 'experimenting',
-        homepage: 'https://code.visualstudio.com',
-        note: 'Agent mode brings Cursor-style autonomous edits into plain VS Code, so it can now operate inside a repo. Trying it as a lighter-weight alternative to a dedicated AI editor.',
-        pros: [
-          'Agent mode closes much of the gap with Cursor',
-          'Familiar editor I already know well',
-        ],
-        cons: ['Still deciding whether it earns a daily-driver slot'],
-      },
-      {
-        title: 'Copilot CLI',
-        tags: ['github', 'cli', 'agent'],
-        badge: 'experimenting',
-        homepage: 'https://github.com/github/copilot-cli',
-        note: "GitHub's terminal agent. Poking at it to see how it compares with Claude Code and Codex CLI in the same Warp workflow.",
-        pros: [
-          'Lives in the terminal alongside my other CLIs',
-          'Tied into the GitHub ecosystem I already use',
-        ],
-        cons: ['Too early to say where it lands versus the CLIs I run daily'],
-      },
     ],
   },
   {
@@ -260,6 +252,15 @@ export const fieldNotesSections: FieldNoteSection[] = [
         note: 'The plan behind my Codex work and GPT-5.6 access. I am still confirming the cleanest public-facing name for the exact Codex tier.',
         pros: ['Makes Codex a real daily agent instead of an occasional backup'],
         cons: ['Naming around the Codex tiers is easy to make too messy'],
+      },
+      {
+        title: 'OpenCode Go',
+        tags: ['opencode', 'Go plan'],
+        badge: 'experimenting',
+        homepage: 'https://opencode.ai',
+        note: 'The plan behind OpenCode and my Kimi K3 access. Cheap enough to keep a third harness in the rotation without thinking about it.',
+        pros: ['Puts an open-weight model in the same loop as the big two'],
+        cons: ['Only earns its slot if OpenCode does'],
       },
       {
         title: 'Warp Build',

--- a/src/data/field-notes.ts
+++ b/src/data/field-notes.ts
@@ -99,7 +99,7 @@ export const fieldNotesSections: FieldNoteSection[] = [
     id: 'coding-agents',
     title: 'Harnesses',
     blurb:
-      'The agent loop itself — the thing that takes a model, gives it tools, and lets it inspect a repo, edit, and run checks. Each harness is tied to a vendor’s models; the interface I drive it from is a separate choice.',
+      'The agent loop itself — the thing that takes a model, gives it tools, and lets it inspect a repo, edit, and run checks. Claude Code and Codex each run their own vendor’s models; OpenCode runs anything. The interface I drive a harness from is a separate choice.',
     items: [
       {
         title: 'Claude Code',


### PR DESCRIPTION
Follow-up to #300.

The field notes blurred two different things: the harness (the agent loop that runs a model inside a repo — Claude Code, Codex, OpenCode) and the interface I drive it from (T3 Code, Warp, the desktop apps). T3 Code was filed as a harness when it is really an interface over all three. The "Current workflow" section also said orchestration comes first, with Hermes as the entry point — which is backwards; nearly all the work happens locally on the Mac.

Changes:

- "Current workflow" section removed. Its loop thesis (context → inspect → edit → check → review → iterate) moves into the page lede where it frames everything below.
- Hermes Agent moves to Evaluating, reworded as the remote/async lane from my phone rather than the start of the loop. M1 MacBook Pro moves to Infrastructure as the local box next to the VPS.
- Models moves to the top — model, then harness, then interface, matching how the choice is actually made. Blurb no longer claims a ranking order.
- "Coding agents & harnesses" becomes "Harnesses" with Claude Code, Codex (dropped "CLI"), and OpenCode (new, `experimenting`, on the Go plan).
- T3 Code moves to the top of Interfaces and is described as an interface over three harnesses, not a harness itself.
- Claude desktop and Codex desktop badged `occasional` (new badge value; rendered as plain text so no component change beyond the type).
- VS Code and Copilot CLI dropped from Evaluating — not in use right now. Oz stays.
- OpenCode Go added to Subscriptions.

Copy and ordering only — no layout changes, so no screenshot.

Verified: `pnpm check` (eslint, tsc, jest 133/133) passes; prettier clean.

_Filed by claude-fable-5 via Claude Code (T3 Code)._

🤖 Generated with [Claude Code](https://claude.com/claude-code)